### PR TITLE
Swift 3 compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "Frameworks/Prelude"]
 	path = Frameworks/Prelude
 	url = https://github.com/kickstarter/Kickstarter-Prelude.git
+[submodule "Frameworks/Runes"]
+	path = Frameworks/Runes
+	url = https://github.com/thoughtbot/Runes.git

--- a/KsApi.playground/Contents.swift
+++ b/KsApi.playground/Contents.swift
@@ -42,7 +42,7 @@ categories
 service.fetchActivities()
   .flatMap(.Concat) { SignalProducer<Activity, ErrorEnvelope>(values: $0.activities) }
   .map { $0.user?.name }
-  .ignoreNil()
+  .skipNil()
   .startWithNext { name in
     print("Activity user's name: \(name)")
 }

--- a/KsApi.playground/contents.xcplayground
+++ b/KsApi.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios' display-mode='raw' executeOnSourceChanges='false'>
+<playground version='5.0' target-platform='ios' display-mode='raw' executeOnSourceChanges='false' last-migration='0820'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/KsApi.xcodeproj/project.pbxproj
+++ b/KsApi.xcodeproj/project.pbxproj
@@ -372,6 +372,8 @@
 		A796A8C31D48EAE9009B6EF6 /* RewardsItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A796A8C11D48EAE9009B6EF6 /* RewardsItemTests.swift */; };
 		A796A8D41D48EAF8009B6EF6 /* ItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A796A8D31D48EAF8009B6EF6 /* ItemTests.swift */; };
 		A796A8D51D48EAF8009B6EF6 /* ItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A796A8D31D48EAF8009B6EF6 /* ItemTests.swift */; };
+		A79BE7FE1E071F6A0077A9B2 /* Runes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE7EF1E071F5C0077A9B2 /* Runes.framework */; };
+		A79BE8011E071F720077A9B2 /* Runes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE7F31E071F5C0077A9B2 /* Runes.framework */; };
 		A7AFC3611D231B0B00C99E2A /* ProjectStatsEnvelope.CumulativeStatsLenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7AFC3601D231B0B00C99E2A /* ProjectStatsEnvelope.CumulativeStatsLenses.swift */; };
 		A7AFC3621D231B0B00C99E2A /* ProjectStatsEnvelope.CumulativeStatsLenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7AFC3601D231B0B00C99E2A /* ProjectStatsEnvelope.CumulativeStatsLenses.swift */; };
 		A7BBF31D1C2F95E400AC62B4 /* ServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7BBF31C1C2F95E400AC62B4 /* ServiceTests.swift */; };
@@ -650,6 +652,69 @@
 			remoteGlobalIDString = A7DB1D391C9F355E008244DA;
 			remoteInfo = "ReactiveExtensions-TestHelpers-iOS";
 		};
+		A79BE7EE1E071F5C0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F802D4D21A5F218E005E236C;
+			remoteInfo = "Runes-iOS";
+		};
+		A79BE7F01E071F5C0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F86B2E0B1A5F2B8D00C3B8BD;
+			remoteInfo = "Runes-Mac";
+		};
+		A79BE7F21E071F5C0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 51DE8A121BAB363500124320;
+			remoteInfo = "Runes-tvOS";
+		};
+		A79BE7F41E071F5C0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F8624C261A645A9600C883B3;
+			remoteInfo = "Runes-iOS Tests";
+		};
+		A79BE7F61E071F5C0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F8624C451A645C9500C883B3;
+			remoteInfo = "Runes-Mac Tests";
+		};
+		A79BE7F81E071F5C0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 51DE8A211BAB36E600124320;
+			remoteInfo = "Runes-tvOS Tests";
+		};
+		A79BE7FA1E071F5C0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EAA6A5101B2F154D0058E9A8;
+			remoteInfo = "Runes-watchOS";
+		};
+		A79BE7FC1E071F650077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = F802D4D11A5F218E005E236C;
+			remoteInfo = "Runes-iOS";
+		};
+		A79BE7FF1E071F6F0077A9B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 51DE8A111BAB363500124320;
+			remoteInfo = "Runes-tvOS";
+		};
 		A7FD09D41C83E8FE00332CCB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = CA43C5F01BB358F200C180DA /* Project object */;
@@ -845,6 +910,7 @@
 		A796649C1D52213100454C84 /* MessageSubject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageSubject.swift; sourceTree = "<group>"; };
 		A796A8C11D48EAE9009B6EF6 /* RewardsItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardsItemTests.swift; sourceTree = "<group>"; };
 		A796A8D31D48EAF8009B6EF6 /* ItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItemTests.swift; sourceTree = "<group>"; };
+		A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Runes.xcodeproj; path = Frameworks/Argo/Carthage/Checkouts/Runes/Runes.xcodeproj; sourceTree = "<group>"; };
 		A7AFC3601D231B0B00C99E2A /* ProjectStatsEnvelope.CumulativeStatsLenses.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectStatsEnvelope.CumulativeStatsLenses.swift; sourceTree = "<group>"; };
 		A7BBF31C1C2F95E400AC62B4 /* ServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ServiceTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		A7C8DDAD1DE4FC4E008DDA9A /* Secrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Secrets.swift; path = "Frameworks/native-secrets/ios/Secrets.swift"; sourceTree = SOURCE_ROOT; };
@@ -874,6 +940,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A79BE7FE1E071F6A0077A9B2 /* Runes.framework in Frameworks */,
 				A73639881D03559C00445B24 /* Argo.framework in Frameworks */,
 				A73639891D03559C00445B24 /* Curry.framework in Frameworks */,
 				A736398A1D03559C00445B24 /* Prelude.framework in Frameworks */,
@@ -894,6 +961,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A79BE8011E071F720077A9B2 /* Runes.framework in Frameworks */,
 				A7363AB81D035A4B00445B24 /* Argo.framework in Frameworks */,
 				A7363AB91D035A4B00445B24 /* Curry.framework in Frameworks */,
 				A7363ABA1D035A4B00445B24 /* Prelude.framework in Frameworks */,
@@ -1208,6 +1276,20 @@
 			path = KsApiTests;
 			sourceTree = "<group>";
 		};
+		A79BE7D61E071F5C0077A9B2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A79BE7EF1E071F5C0077A9B2 /* Runes.framework */,
+				A79BE7F11E071F5C0077A9B2 /* Runes.framework */,
+				A79BE7F31E071F5C0077A9B2 /* Runes.framework */,
+				A79BE7F51E071F5C0077A9B2 /* Runes-iOS Tests.xctest */,
+				A79BE7F71E071F5C0077A9B2 /* Runes-Mac Tests.xctest */,
+				A79BE7F91E071F5C0077A9B2 /* Runes-tvOS Tests.xctest */,
+				A79BE7FB1E071F5C0077A9B2 /* Runes.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		A7FD099F1C83E77B00332CCB /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -1215,6 +1297,7 @@
 				A73639321D03550700445B24 /* Curry.xcodeproj */,
 				A73639411D03550C00445B24 /* Prelude.xcodeproj */,
 				A73639501D03551000445B24 /* ReactiveExtensions.xcodeproj */,
+				A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1313,6 +1396,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				A79BE7FD1E071F650077A9B2 /* PBXTargetDependency */,
 				A73639801D03556C00445B24 /* PBXTargetDependency */,
 				A73639821D03556F00445B24 /* PBXTargetDependency */,
 				A73639841D03557200445B24 /* PBXTargetDependency */,
@@ -1354,6 +1438,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				A79BE8001E071F6F0077A9B2 /* PBXTargetDependency */,
 				A7363AB01D035A3900445B24 /* PBXTargetDependency */,
 				A7363AB21D035A3900445B24 /* PBXTargetDependency */,
 				A7363AB41D035A3900445B24 /* PBXTargetDependency */,
@@ -1371,17 +1456,17 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = Kickstarter;
 				TargetAttributes = {
 					A753B5681C2EED9800FDB616 = {
 						CreatedOnToolsVersion = 7.2;
 					};
 					A7FD096E1C83E74F00332CCB = {
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0820;
 					};
 					A7FD09C21C83E8E900332CCB = {
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0820;
 					};
 					CA43C5F81BB358F200C180DA = {
 						CreatedOnToolsVersion = 7.1;
@@ -1415,6 +1500,10 @@
 				{
 					ProductGroup = A73639511D03551000445B24 /* Products */;
 					ProjectRef = A73639501D03551000445B24 /* ReactiveExtensions.xcodeproj */;
+				},
+				{
+					ProductGroup = A79BE7D61E071F5C0077A9B2 /* Products */;
+					ProjectRef = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -1601,6 +1690,55 @@
 			fileType = wrapper.cfbundle;
 			path = "Prelude-UIKit-tvOSTests.xctest";
 			remoteRef = A757E9B01D19903500A5C978 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		A79BE7EF1E071F5C0077A9B2 /* Runes.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Runes.framework;
+			remoteRef = A79BE7EE1E071F5C0077A9B2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		A79BE7F11E071F5C0077A9B2 /* Runes.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Runes.framework;
+			remoteRef = A79BE7F01E071F5C0077A9B2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		A79BE7F31E071F5C0077A9B2 /* Runes.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Runes.framework;
+			remoteRef = A79BE7F21E071F5C0077A9B2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		A79BE7F51E071F5C0077A9B2 /* Runes-iOS Tests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "Runes-iOS Tests.xctest";
+			remoteRef = A79BE7F41E071F5C0077A9B2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		A79BE7F71E071F5C0077A9B2 /* Runes-Mac Tests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "Runes-Mac Tests.xctest";
+			remoteRef = A79BE7F61E071F5C0077A9B2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		A79BE7F91E071F5C0077A9B2 /* Runes-tvOS Tests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "Runes-tvOS Tests.xctest";
+			remoteRef = A79BE7F81E071F5C0077A9B2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		A79BE7FB1E071F5C0077A9B2 /* Runes.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Runes.framework;
+			remoteRef = A79BE7FA1E071F5C0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -2097,6 +2235,16 @@
 			name = "ReactiveExtensions-TestHelpers-iOS";
 			targetProxy = A75CAC581D138D6600EBF323 /* PBXContainerItemProxy */;
 		};
+		A79BE7FD1E071F650077A9B2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Runes-iOS";
+			targetProxy = A79BE7FC1E071F650077A9B2 /* PBXContainerItemProxy */;
+		};
+		A79BE8001E071F6F0077A9B2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Runes-tvOS";
+			targetProxy = A79BE7FF1E071F6F0077A9B2 /* PBXContainerItemProxy */;
+		};
 		A7FD09D51C83E8FE00332CCB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = A7FD096E1C83E74F00332CCB /* KsApi-iOS */;
@@ -2136,6 +2284,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -2147,7 +2296,6 @@
 				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -2157,6 +2305,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -2168,7 +2317,6 @@
 				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -2183,7 +2331,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kickstarter.KsApiTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -2198,7 +2345,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kickstarter.KsApiTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -2217,8 +2363,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
@@ -2249,6 +2397,7 @@
 				PRODUCT_NAME = KsApi;
 				STRIP_BITCODE_FROM_COPIED_FILES = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -2270,8 +2419,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
@@ -2295,6 +2446,7 @@
 				PRODUCT_NAME = KsApi;
 				STRIP_BITCODE_FROM_COPIED_FILES = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
@@ -2308,7 +2460,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -2328,7 +2480,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/KsApi.xcodeproj/project.pbxproj
+++ b/KsApi.xcodeproj/project.pbxproj
@@ -372,8 +372,8 @@
 		A796A8C31D48EAE9009B6EF6 /* RewardsItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A796A8C11D48EAE9009B6EF6 /* RewardsItemTests.swift */; };
 		A796A8D41D48EAF8009B6EF6 /* ItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A796A8D31D48EAF8009B6EF6 /* ItemTests.swift */; };
 		A796A8D51D48EAF8009B6EF6 /* ItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A796A8D31D48EAF8009B6EF6 /* ItemTests.swift */; };
-		A79BE7FE1E071F6A0077A9B2 /* Runes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE7EF1E071F5C0077A9B2 /* Runes.framework */; };
-		A79BE8011E071F720077A9B2 /* Runes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE7F31E071F5C0077A9B2 /* Runes.framework */; };
+		A79BE81C1E0720D70077A9B2 /* Runes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE80D1E0720CA0077A9B2 /* Runes.framework */; };
+		A79BE81F1E0720E40077A9B2 /* Runes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A79BE8111E0720CA0077A9B2 /* Runes.framework */; };
 		A7AFC3611D231B0B00C99E2A /* ProjectStatsEnvelope.CumulativeStatsLenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7AFC3601D231B0B00C99E2A /* ProjectStatsEnvelope.CumulativeStatsLenses.swift */; };
 		A7AFC3621D231B0B00C99E2A /* ProjectStatsEnvelope.CumulativeStatsLenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7AFC3601D231B0B00C99E2A /* ProjectStatsEnvelope.CumulativeStatsLenses.swift */; };
 		A7BBF31D1C2F95E400AC62B4 /* ServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7BBF31C1C2F95E400AC62B4 /* ServiceTests.swift */; };
@@ -652,65 +652,65 @@
 			remoteGlobalIDString = A7DB1D391C9F355E008244DA;
 			remoteInfo = "ReactiveExtensions-TestHelpers-iOS";
 		};
-		A79BE7EE1E071F5C0077A9B2 /* PBXContainerItemProxy */ = {
+		A79BE80C1E0720CA0077A9B2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			containerPortal = A79BE8021E0720CA0077A9B2 /* Runes.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = F802D4D21A5F218E005E236C;
 			remoteInfo = "Runes-iOS";
 		};
-		A79BE7F01E071F5C0077A9B2 /* PBXContainerItemProxy */ = {
+		A79BE80E1E0720CA0077A9B2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			containerPortal = A79BE8021E0720CA0077A9B2 /* Runes.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = F86B2E0B1A5F2B8D00C3B8BD;
 			remoteInfo = "Runes-Mac";
 		};
-		A79BE7F21E071F5C0077A9B2 /* PBXContainerItemProxy */ = {
+		A79BE8101E0720CA0077A9B2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			containerPortal = A79BE8021E0720CA0077A9B2 /* Runes.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 51DE8A121BAB363500124320;
 			remoteInfo = "Runes-tvOS";
 		};
-		A79BE7F41E071F5C0077A9B2 /* PBXContainerItemProxy */ = {
+		A79BE8121E0720CA0077A9B2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			containerPortal = A79BE8021E0720CA0077A9B2 /* Runes.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = F8624C261A645A9600C883B3;
 			remoteInfo = "Runes-iOS Tests";
 		};
-		A79BE7F61E071F5C0077A9B2 /* PBXContainerItemProxy */ = {
+		A79BE8141E0720CA0077A9B2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			containerPortal = A79BE8021E0720CA0077A9B2 /* Runes.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = F8624C451A645C9500C883B3;
 			remoteInfo = "Runes-Mac Tests";
 		};
-		A79BE7F81E071F5C0077A9B2 /* PBXContainerItemProxy */ = {
+		A79BE8161E0720CA0077A9B2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			containerPortal = A79BE8021E0720CA0077A9B2 /* Runes.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 51DE8A211BAB36E600124320;
 			remoteInfo = "Runes-tvOS Tests";
 		};
-		A79BE7FA1E071F5C0077A9B2 /* PBXContainerItemProxy */ = {
+		A79BE8181E0720CA0077A9B2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			containerPortal = A79BE8021E0720CA0077A9B2 /* Runes.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = EAA6A5101B2F154D0058E9A8;
 			remoteInfo = "Runes-watchOS";
 		};
-		A79BE7FC1E071F650077A9B2 /* PBXContainerItemProxy */ = {
+		A79BE81A1E0720D20077A9B2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			containerPortal = A79BE8021E0720CA0077A9B2 /* Runes.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = F802D4D11A5F218E005E236C;
 			remoteInfo = "Runes-iOS";
 		};
-		A79BE7FF1E071F6F0077A9B2 /* PBXContainerItemProxy */ = {
+		A79BE81D1E0720E00077A9B2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+			containerPortal = A79BE8021E0720CA0077A9B2 /* Runes.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = 51DE8A111BAB363500124320;
 			remoteInfo = "Runes-tvOS";
@@ -910,7 +910,7 @@
 		A796649C1D52213100454C84 /* MessageSubject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageSubject.swift; sourceTree = "<group>"; };
 		A796A8C11D48EAE9009B6EF6 /* RewardsItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardsItemTests.swift; sourceTree = "<group>"; };
 		A796A8D31D48EAF8009B6EF6 /* ItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItemTests.swift; sourceTree = "<group>"; };
-		A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Runes.xcodeproj; path = Frameworks/Argo/Carthage/Checkouts/Runes/Runes.xcodeproj; sourceTree = "<group>"; };
+		A79BE8021E0720CA0077A9B2 /* Runes.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Runes.xcodeproj; path = Frameworks/Runes/Runes.xcodeproj; sourceTree = "<group>"; };
 		A7AFC3601D231B0B00C99E2A /* ProjectStatsEnvelope.CumulativeStatsLenses.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectStatsEnvelope.CumulativeStatsLenses.swift; sourceTree = "<group>"; };
 		A7BBF31C1C2F95E400AC62B4 /* ServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ServiceTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		A7C8DDAD1DE4FC4E008DDA9A /* Secrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Secrets.swift; path = "Frameworks/native-secrets/ios/Secrets.swift"; sourceTree = SOURCE_ROOT; };
@@ -940,7 +940,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A79BE7FE1E071F6A0077A9B2 /* Runes.framework in Frameworks */,
+				A79BE81C1E0720D70077A9B2 /* Runes.framework in Frameworks */,
 				A73639881D03559C00445B24 /* Argo.framework in Frameworks */,
 				A73639891D03559C00445B24 /* Curry.framework in Frameworks */,
 				A736398A1D03559C00445B24 /* Prelude.framework in Frameworks */,
@@ -961,7 +961,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A79BE8011E071F720077A9B2 /* Runes.framework in Frameworks */,
+				A79BE81F1E0720E40077A9B2 /* Runes.framework in Frameworks */,
 				A7363AB81D035A4B00445B24 /* Argo.framework in Frameworks */,
 				A7363AB91D035A4B00445B24 /* Curry.framework in Frameworks */,
 				A7363ABA1D035A4B00445B24 /* Prelude.framework in Frameworks */,
@@ -1276,16 +1276,16 @@
 			path = KsApiTests;
 			sourceTree = "<group>";
 		};
-		A79BE7D61E071F5C0077A9B2 /* Products */ = {
+		A79BE8031E0720CA0077A9B2 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				A79BE7EF1E071F5C0077A9B2 /* Runes.framework */,
-				A79BE7F11E071F5C0077A9B2 /* Runes.framework */,
-				A79BE7F31E071F5C0077A9B2 /* Runes.framework */,
-				A79BE7F51E071F5C0077A9B2 /* Runes-iOS Tests.xctest */,
-				A79BE7F71E071F5C0077A9B2 /* Runes-Mac Tests.xctest */,
-				A79BE7F91E071F5C0077A9B2 /* Runes-tvOS Tests.xctest */,
-				A79BE7FB1E071F5C0077A9B2 /* Runes.framework */,
+				A79BE80D1E0720CA0077A9B2 /* Runes.framework */,
+				A79BE80F1E0720CA0077A9B2 /* Runes.framework */,
+				A79BE8111E0720CA0077A9B2 /* Runes.framework */,
+				A79BE8131E0720CA0077A9B2 /* Runes-iOS Tests.xctest */,
+				A79BE8151E0720CA0077A9B2 /* Runes-Mac Tests.xctest */,
+				A79BE8171E0720CA0077A9B2 /* Runes-tvOS Tests.xctest */,
+				A79BE8191E0720CA0077A9B2 /* Runes.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1297,7 +1297,7 @@
 				A73639321D03550700445B24 /* Curry.xcodeproj */,
 				A73639411D03550C00445B24 /* Prelude.xcodeproj */,
 				A73639501D03551000445B24 /* ReactiveExtensions.xcodeproj */,
-				A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */,
+				A79BE8021E0720CA0077A9B2 /* Runes.xcodeproj */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1396,7 +1396,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				A79BE7FD1E071F650077A9B2 /* PBXTargetDependency */,
+				A79BE81B1E0720D20077A9B2 /* PBXTargetDependency */,
 				A73639801D03556C00445B24 /* PBXTargetDependency */,
 				A73639821D03556F00445B24 /* PBXTargetDependency */,
 				A73639841D03557200445B24 /* PBXTargetDependency */,
@@ -1438,7 +1438,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				A79BE8001E071F6F0077A9B2 /* PBXTargetDependency */,
+				A79BE81E1E0720E00077A9B2 /* PBXTargetDependency */,
 				A7363AB01D035A3900445B24 /* PBXTargetDependency */,
 				A7363AB21D035A3900445B24 /* PBXTargetDependency */,
 				A7363AB41D035A3900445B24 /* PBXTargetDependency */,
@@ -1502,8 +1502,8 @@
 					ProjectRef = A73639501D03551000445B24 /* ReactiveExtensions.xcodeproj */;
 				},
 				{
-					ProductGroup = A79BE7D61E071F5C0077A9B2 /* Products */;
-					ProjectRef = A79BE7D51E071F5C0077A9B2 /* Runes.xcodeproj */;
+					ProductGroup = A79BE8031E0720CA0077A9B2 /* Products */;
+					ProjectRef = A79BE8021E0720CA0077A9B2 /* Runes.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -1692,53 +1692,53 @@
 			remoteRef = A757E9B01D19903500A5C978 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		A79BE7EF1E071F5C0077A9B2 /* Runes.framework */ = {
+		A79BE80D1E0720CA0077A9B2 /* Runes.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = Runes.framework;
-			remoteRef = A79BE7EE1E071F5C0077A9B2 /* PBXContainerItemProxy */;
+			remoteRef = A79BE80C1E0720CA0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		A79BE7F11E071F5C0077A9B2 /* Runes.framework */ = {
+		A79BE80F1E0720CA0077A9B2 /* Runes.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = Runes.framework;
-			remoteRef = A79BE7F01E071F5C0077A9B2 /* PBXContainerItemProxy */;
+			remoteRef = A79BE80E1E0720CA0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		A79BE7F31E071F5C0077A9B2 /* Runes.framework */ = {
+		A79BE8111E0720CA0077A9B2 /* Runes.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = Runes.framework;
-			remoteRef = A79BE7F21E071F5C0077A9B2 /* PBXContainerItemProxy */;
+			remoteRef = A79BE8101E0720CA0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		A79BE7F51E071F5C0077A9B2 /* Runes-iOS Tests.xctest */ = {
+		A79BE8131E0720CA0077A9B2 /* Runes-iOS Tests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = "Runes-iOS Tests.xctest";
-			remoteRef = A79BE7F41E071F5C0077A9B2 /* PBXContainerItemProxy */;
+			remoteRef = A79BE8121E0720CA0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		A79BE7F71E071F5C0077A9B2 /* Runes-Mac Tests.xctest */ = {
+		A79BE8151E0720CA0077A9B2 /* Runes-Mac Tests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = "Runes-Mac Tests.xctest";
-			remoteRef = A79BE7F61E071F5C0077A9B2 /* PBXContainerItemProxy */;
+			remoteRef = A79BE8141E0720CA0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		A79BE7F91E071F5C0077A9B2 /* Runes-tvOS Tests.xctest */ = {
+		A79BE8171E0720CA0077A9B2 /* Runes-tvOS Tests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = "Runes-tvOS Tests.xctest";
-			remoteRef = A79BE7F81E071F5C0077A9B2 /* PBXContainerItemProxy */;
+			remoteRef = A79BE8161E0720CA0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		A79BE7FB1E071F5C0077A9B2 /* Runes.framework */ = {
+		A79BE8191E0720CA0077A9B2 /* Runes.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = Runes.framework;
-			remoteRef = A79BE7FA1E071F5C0077A9B2 /* PBXContainerItemProxy */;
+			remoteRef = A79BE8181E0720CA0077A9B2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -2235,15 +2235,15 @@
 			name = "ReactiveExtensions-TestHelpers-iOS";
 			targetProxy = A75CAC581D138D6600EBF323 /* PBXContainerItemProxy */;
 		};
-		A79BE7FD1E071F650077A9B2 /* PBXTargetDependency */ = {
+		A79BE81B1E0720D20077A9B2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Runes-iOS";
-			targetProxy = A79BE7FC1E071F650077A9B2 /* PBXContainerItemProxy */;
+			targetProxy = A79BE81A1E0720D20077A9B2 /* PBXContainerItemProxy */;
 		};
-		A79BE8001E071F6F0077A9B2 /* PBXTargetDependency */ = {
+		A79BE81E1E0720E00077A9B2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Runes-tvOS";
-			targetProxy = A79BE7FF1E071F6F0077A9B2 /* PBXContainerItemProxy */;
+			targetProxy = A79BE81D1E0720E00077A9B2 /* PBXContainerItemProxy */;
 		};
 		A7FD09D51C83E8FE00332CCB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/KsApi.xcodeproj/xcshareddata/xcschemes/KsApi-TestHelpers-iOS.xcscheme
+++ b/KsApi.xcodeproj/xcshareddata/xcschemes/KsApi-TestHelpers-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/KsApi.xcodeproj/xcshareddata/xcschemes/KsApi-TestHelpers-tvOS.xcscheme
+++ b/KsApi.xcodeproj/xcshareddata/xcschemes/KsApi-TestHelpers-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/KsApi.xcodeproj/xcshareddata/xcschemes/KsApi-iOS.xcscheme
+++ b/KsApi.xcodeproj/xcshareddata/xcschemes/KsApi-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/KsApi.xcodeproj/xcshareddata/xcschemes/KsApi-tvOS.xcscheme
+++ b/KsApi.xcodeproj/xcshareddata/xcschemes/KsApi-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable file_length
 // swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
-import ReactiveCocoa
+import ReactiveSwift
 import Prelude
 
 internal struct MockService: ServiceType {
@@ -286,7 +286,7 @@ internal struct MockService: ServiceType {
       .template |> Activity.lens.category .~ .backing,
       .template |> Activity.lens.category .~ .commentProject
       ]
-      .enumerate()
+      .enumerated()
       .map(Activity.lens.id.set)
 
     self.fetchProjectActivitiesError = fetchProjectActivitiesError
@@ -566,7 +566,7 @@ internal struct MockService: ServiceType {
       }
       let envelope = self.fetchDiscoveryResponse ?? (.template
         |> DiscoveryEnvelope.lens.projects .~ (1...4).map(project)
-        |> DiscoveryEnvelope.lens.urls.api.moreProjects .~ paginationUrl + "+1"
+        |> DiscoveryEnvelope.lens.urls.api.moreProjects .~ (paginationUrl + "+1")
       )
 
       return SignalProducer(value: envelope)
@@ -1074,7 +1074,7 @@ internal struct MockService: ServiceType {
     return SignalProducer(value: self.updatePledgeResponse)
   }
 
-  internal func addImage(file fileURL: NSURL, toDraft draft: UpdateDraft)
+  internal func addImage(file fileURL: URL, toDraft draft: UpdateDraft)
     -> SignalProducer<UpdateDraft.Image, ErrorEnvelope> {
 
       if let error = addAttachmentError {
@@ -1094,7 +1094,7 @@ internal struct MockService: ServiceType {
       return SignalProducer(value: removeAttachmentResponse ?? .template)
   }
 
-  internal func addVideo(file fileURL: NSURL, toDraft draft: UpdateDraft)
+  internal func addVideo(file fileURL: URL, toDraft draft: UpdateDraft)
     -> SignalProducer<UpdateDraft.Video, ErrorEnvelope> {
 
       return .empty

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -11,115 +11,115 @@ internal struct MockService: ServiceType {
   internal let language: String
   internal let buildVersion: String
 
-  private let changePaymentMethodResponse: ChangePaymentMethodEnvelope
+  fileprivate let changePaymentMethodResponse: ChangePaymentMethodEnvelope
 
-  private let createPledgeResponse: CreatePledgeEnvelope
+  fileprivate let createPledgeResponse: CreatePledgeEnvelope
 
-  private let facebookConnectResponse: User?
-  private let facebookConnectError: ErrorEnvelope?
+  fileprivate let facebookConnectResponse: User?
+  fileprivate let facebookConnectError: ErrorEnvelope?
 
-  private let fetchActivitiesResponse: [Activity]?
-  private let fetchActivitiesError: ErrorEnvelope?
+  fileprivate let fetchActivitiesResponse: [Activity]?
+  fileprivate let fetchActivitiesError: ErrorEnvelope?
 
-  private let fetchBackingResponse: Backing
+  fileprivate let fetchBackingResponse: Backing
 
-  private let fetchCategoriesResponse: CategoriesEnvelope?
+  fileprivate let fetchCategoriesResponse: CategoriesEnvelope?
 
-  private let fetchCheckoutResponse: CheckoutEnvelope?
-  private let fetchCheckoutError: ErrorEnvelope?
+  fileprivate let fetchCheckoutResponse: CheckoutEnvelope?
+  fileprivate let fetchCheckoutError: ErrorEnvelope?
 
-  private let fetchCommentsResponse: [Comment]?
-  private let fetchCommentsError: ErrorEnvelope?
+  fileprivate let fetchCommentsResponse: [Comment]?
+  fileprivate let fetchCommentsError: ErrorEnvelope?
 
-  private let fetchConfigResponse: Config?
+  fileprivate let fetchConfigResponse: Config?
 
-  private let fetchDiscoveryResponse: DiscoveryEnvelope?
-  private let fetchDiscoveryError: ErrorEnvelope?
+  fileprivate let fetchDiscoveryResponse: DiscoveryEnvelope?
+  fileprivate let fetchDiscoveryError: ErrorEnvelope?
 
-  private let fetchFriendsResponse: FindFriendsEnvelope?
-  private let fetchFriendsError: ErrorEnvelope?
+  fileprivate let fetchFriendsResponse: FindFriendsEnvelope?
+  fileprivate let fetchFriendsError: ErrorEnvelope?
 
-  private let fetchFriendStatsResponse: FriendStatsEnvelope?
-  private let fetchFriendStatsError: ErrorEnvelope?
+  fileprivate let fetchFriendStatsResponse: FriendStatsEnvelope?
+  fileprivate let fetchFriendStatsError: ErrorEnvelope?
 
-  private let fetchDraftResponse: UpdateDraft?
-  private let fetchDraftError: ErrorEnvelope?
+  fileprivate let fetchDraftResponse: UpdateDraft?
+  fileprivate let fetchDraftError: ErrorEnvelope?
 
-  private let addAttachmentResponse: UpdateDraft.Image?
-  private let addAttachmentError: ErrorEnvelope?
-  private let removeAttachmentResponse: UpdateDraft.Image?
-  private let removeAttachmentError: ErrorEnvelope?
+  fileprivate let addAttachmentResponse: UpdateDraft.Image?
+  fileprivate let addAttachmentError: ErrorEnvelope?
+  fileprivate let removeAttachmentResponse: UpdateDraft.Image?
+  fileprivate let removeAttachmentError: ErrorEnvelope?
 
-  private let publishUpdateError: ErrorEnvelope?
+  fileprivate let publishUpdateError: ErrorEnvelope?
 
-  private let fetchMessageThreadResponse: MessageThread
-  private let fetchMessageThreadsResponse: [MessageThread]
+  fileprivate let fetchMessageThreadResponse: MessageThread
+  fileprivate let fetchMessageThreadsResponse: [MessageThread]
 
-  private let fetchProjectResponse: Project?
+  fileprivate let fetchProjectResponse: Project?
 
-  private let fetchProjectNotificationsResponse: [ProjectNotification]
+  fileprivate let fetchProjectNotificationsResponse: [ProjectNotification]
 
-  private let fetchProjectsResponse: [Project]?
-  private let fetchProjectsError: ErrorEnvelope?
+  fileprivate let fetchProjectsResponse: [Project]?
+  fileprivate let fetchProjectsError: ErrorEnvelope?
 
-  private let fetchProjectStatsResponse: ProjectStatsEnvelope?
-  private let fetchProjectStatsError: ErrorEnvelope?
+  fileprivate let fetchProjectStatsResponse: ProjectStatsEnvelope?
+  fileprivate let fetchProjectStatsError: ErrorEnvelope?
 
-  private let fetchShippingRulesResponse: [ShippingRule]
+  fileprivate let fetchShippingRulesResponse: [ShippingRule]
 
-  private let fetchSurveyResponseResponse: SurveyResponse?
-  private let fetchSurveyResponseError: ErrorEnvelope?
+  fileprivate let fetchSurveyResponseResponse: SurveyResponse?
+  fileprivate let fetchSurveyResponseError: ErrorEnvelope?
 
-  private let fetchUnansweredSurveyResponsesResponse: [SurveyResponse]
+  fileprivate let fetchUnansweredSurveyResponsesResponse: [SurveyResponse]
 
-  private let fetchUpdateResponse: Update
+  fileprivate let fetchUpdateResponse: Update
 
-  private let fetchUserProjectsBackedResponse: [Project]?
-  private let fetchUserProjectsBackedError: ErrorEnvelope?
+  fileprivate let fetchUserProjectsBackedResponse: [Project]?
+  fileprivate let fetchUserProjectsBackedError: ErrorEnvelope?
 
-  private let fetchUserResponse: User?
-  private let fetchUserError: ErrorEnvelope?
+  fileprivate let fetchUserResponse: User?
+  fileprivate let fetchUserError: ErrorEnvelope?
 
-  private let fetchUserSelfResponse: User?
-  private let fetchUserSelfError: ErrorEnvelope?
+  fileprivate let fetchUserSelfResponse: User?
+  fileprivate let fetchUserSelfError: ErrorEnvelope?
 
-  private let followFriendError: ErrorEnvelope?
+  fileprivate let followFriendError: ErrorEnvelope?
 
-  private let incrementVideoCompletionError: ErrorEnvelope?
+  fileprivate let incrementVideoCompletionError: ErrorEnvelope?
 
-  private let incrementVideoStartError: ErrorEnvelope?
+  fileprivate let incrementVideoStartError: ErrorEnvelope?
 
-  private let postCommentResponse: Comment?
-  private let postCommentError: ErrorEnvelope?
+  fileprivate let postCommentResponse: Comment?
+  fileprivate let postCommentError: ErrorEnvelope?
 
-  private let fetchProjectActivitiesResponse: [Activity]?
-  private let fetchProjectActivitiesError: ErrorEnvelope?
+  fileprivate let fetchProjectActivitiesResponse: [Activity]?
+  fileprivate let fetchProjectActivitiesError: ErrorEnvelope?
 
-  private let loginResponse: AccessTokenEnvelope?
-  private let loginError: ErrorEnvelope?
-  private let resendCodeResponse: ErrorEnvelope?
-  private let resendCodeError: ErrorEnvelope?
+  fileprivate let loginResponse: AccessTokenEnvelope?
+  fileprivate let loginError: ErrorEnvelope?
+  fileprivate let resendCodeResponse: ErrorEnvelope?
+  fileprivate let resendCodeError: ErrorEnvelope?
 
-  private let resetPasswordResponse: User?
-  private let resetPasswordError: ErrorEnvelope?
+  fileprivate let resetPasswordResponse: User?
+  fileprivate let resetPasswordError: ErrorEnvelope?
 
-  private let signupResponse: AccessTokenEnvelope?
-  private let signupError: ErrorEnvelope?
+  fileprivate let signupResponse: AccessTokenEnvelope?
+  fileprivate let signupError: ErrorEnvelope?
 
-  private let submitApplePayResponse: SubmitApplePayEnvelope
+  fileprivate let submitApplePayResponse: SubmitApplePayEnvelope
 
-  private let toggleStarResponse: StarEnvelope?
+  fileprivate let toggleStarResponse: StarEnvelope?
 
-  private let unfollowFriendError: ErrorEnvelope?
+  fileprivate let unfollowFriendError: ErrorEnvelope?
 
-  private let updateDraftError: ErrorEnvelope?
+  fileprivate let updateDraftError: ErrorEnvelope?
 
-  private let updatePledgeResponse: UpdatePledgeEnvelope
+  fileprivate let updatePledgeResponse: UpdatePledgeEnvelope
 
-  private let updateProjectNotificationResponse: ProjectNotification?
-  private let updateProjectNotificationError: ErrorEnvelope?
+  fileprivate let updateProjectNotificationResponse: ProjectNotification?
+  fileprivate let updateProjectNotificationError: ErrorEnvelope?
 
-  private let updateUserSelfError: ErrorEnvelope?
+  fileprivate let updateUserSelfError: ErrorEnvelope?
 
   internal init(appId: String = "com.kickstarter.kickstarter.mock",
                 serverConfig: ServerConfigType,
@@ -367,7 +367,7 @@ internal struct MockService: ServiceType {
     self.updateUserSelfError = updateUserSelfError
   }
 
-  internal func createPledge(project project: Project,
+  internal func createPledge(project: Project,
                              amount: Double,
                              reward: Reward?,
                              shippingLocation: Location?,
@@ -402,7 +402,7 @@ internal struct MockService: ServiceType {
     return SignalProducer(value: .template)
   }
 
-  internal func fetchComments(project project: Project) -> SignalProducer<CommentsEnvelope, ErrorEnvelope> {
+  internal func fetchComments(project: Project) -> SignalProducer<CommentsEnvelope, ErrorEnvelope> {
 
     if let error = fetchCommentsError {
       return SignalProducer(error: error)
@@ -439,7 +439,7 @@ internal struct MockService: ServiceType {
     return .empty
   }
 
-  internal func fetchComments(update update: Update) -> SignalProducer<CommentsEnvelope, ErrorEnvelope> {
+  internal func fetchComments(update: Update) -> SignalProducer<CommentsEnvelope, ErrorEnvelope> {
 
     if let error = fetchCommentsError {
       return SignalProducer(error: error)
@@ -473,7 +473,7 @@ internal struct MockService: ServiceType {
     return SignalProducer(value: .template)
   }
 
-  internal func fetchFriends(paginationUrl paginationUrl: String)
+  internal func fetchFriends(paginationUrl: String)
     -> SignalProducer<FindFriendsEnvelope, ErrorEnvelope> {
     return self.fetchFriends()
   }
@@ -511,7 +511,7 @@ internal struct MockService: ServiceType {
     return SignalProducer(value: VoidEnvelope())
   }
 
-  internal func login(oauthToken: OauthTokenAuthType) -> MockService {
+  internal func login(_ oauthToken: OauthTokenAuthType) -> MockService {
     return self |> MockService.lens.oauthToken .~ oauthToken
   }
 
@@ -519,7 +519,7 @@ internal struct MockService: ServiceType {
     return self |> MockService.lens.oauthToken .~ nil
   }
 
-  internal func fetchActivities(count count: Int?) -> SignalProducer<ActivityEnvelope, ErrorEnvelope> {
+  internal func fetchActivities(count: Int?) -> SignalProducer<ActivityEnvelope, ErrorEnvelope> {
 
     if let error = fetchActivitiesError {
       return SignalProducer(error: error)
@@ -538,7 +538,7 @@ internal struct MockService: ServiceType {
     return .empty
   }
 
-  internal func fetchActivities(paginationUrl paginationUrl: String)
+  internal func fetchActivities(paginationUrl: String)
     -> SignalProducer<ActivityEnvelope, ErrorEnvelope> {
       return self.fetchActivities(count: nil)
   }
@@ -554,14 +554,14 @@ internal struct MockService: ServiceType {
     )
   }
 
-  internal func fetchDiscovery(paginationUrl paginationUrl: String)
+  internal func fetchDiscovery(paginationUrl: String)
     -> SignalProducer<DiscoveryEnvelope, ErrorEnvelope> {
 
       if let error = fetchDiscoveryError {
         return SignalProducer(error: error)
       }
 
-      let project: Int -> Project = {
+      let project: (Int) -> Project = {
         .template |> Project.lens.id .~ ($0 + paginationUrl.hashValue)
       }
       let envelope = self.fetchDiscoveryResponse ?? (.template
@@ -572,14 +572,14 @@ internal struct MockService: ServiceType {
       return SignalProducer(value: envelope)
   }
 
-  internal func fetchDiscovery(params params: DiscoveryParams)
+  internal func fetchDiscovery(params: DiscoveryParams)
     -> SignalProducer<DiscoveryEnvelope, ErrorEnvelope> {
 
       if let error = fetchDiscoveryError {
         return SignalProducer(error: error)
       }
 
-      let project: Int -> Project = {
+      let project: (Int) -> Project = {
         .template |> Project.lens.id %~ const($0 + params.hashValue)
       }
       let envelope = self.fetchDiscoveryResponse ?? (.template
@@ -589,7 +589,7 @@ internal struct MockService: ServiceType {
       return SignalProducer(value: envelope)
   }
 
-  internal func fetchMessageThread(messageThreadId messageThreadId: Int)
+  internal func fetchMessageThread(messageThreadId: Int)
     -> SignalProducer<MessageThreadEnvelope, ErrorEnvelope> {
 
       return SignalProducer(
@@ -605,7 +605,7 @@ internal struct MockService: ServiceType {
       )
   }
 
-  internal func fetchMessageThread(backing backing: Backing)
+  internal func fetchMessageThread(backing: Backing)
     -> SignalProducer<MessageThreadEnvelope, ErrorEnvelope> {
 
       return SignalProducer(
@@ -621,7 +621,7 @@ internal struct MockService: ServiceType {
       )
   }
 
-  internal func fetchMessageThreads(mailbox mailbox: Mailbox, project: Project?)
+  internal func fetchMessageThreads(mailbox: Mailbox, project: Project?)
     -> SignalProducer<MessageThreadsEnvelope, ErrorEnvelope> {
 
       return SignalProducer(value:
@@ -636,7 +636,7 @@ internal struct MockService: ServiceType {
       )
   }
 
-  internal func fetchMessageThreads(paginationUrl paginationUrl: String)
+  internal func fetchMessageThreads(paginationUrl: String)
     -> SignalProducer<MessageThreadsEnvelope, ErrorEnvelope> {
 
       return SignalProducer(value:
@@ -655,7 +655,7 @@ internal struct MockService: ServiceType {
     return SignalProducer(value: self.fetchProjectNotificationsResponse)
   }
 
-  internal func fetchProject(param param: Param) -> SignalProducer<Project, ErrorEnvelope> {
+  internal func fetchProject(param: Param) -> SignalProducer<Project, ErrorEnvelope> {
     if let project = self.fetchProjectResponse {
       return SignalProducer(value: project)
     }
@@ -666,7 +666,7 @@ internal struct MockService: ServiceType {
     )
   }
 
-  internal func fetchProject(params: DiscoveryParams) -> SignalProducer<DiscoveryEnvelope, ErrorEnvelope> {
+  internal func fetchProject(_ params: DiscoveryParams) -> SignalProducer<DiscoveryEnvelope, ErrorEnvelope> {
     if let envelope = self.fetchDiscoveryResponse {
       return SignalProducer(value: envelope)
     }
@@ -677,7 +677,7 @@ internal struct MockService: ServiceType {
     return SignalProducer(value: envelope)
   }
 
-  internal func fetchProject(project project: Project) -> SignalProducer<Project, ErrorEnvelope> {
+  internal func fetchProject(project: Project) -> SignalProducer<Project, ErrorEnvelope> {
     if let project = self.fetchProjectResponse {
       return SignalProducer(value: project)
     }
@@ -704,7 +704,7 @@ internal struct MockService: ServiceType {
     return .empty
   }
 
-  internal func fetchProjectActivities(paginationUrl paginationUrl: String)
+  internal func fetchProjectActivities(paginationUrl: String)
     -> SignalProducer<ProjectActivityEnvelope, ErrorEnvelope> {
 
     if let error = fetchProjectActivitiesError {
@@ -724,7 +724,7 @@ internal struct MockService: ServiceType {
     return .empty
   }
 
-  internal func fetchProjects(member member: Bool) -> SignalProducer<ProjectsEnvelope, ErrorEnvelope> {
+  internal func fetchProjects(member: Bool) -> SignalProducer<ProjectsEnvelope, ErrorEnvelope> {
 
     if let error = fetchProjectsError {
       return SignalProducer(error: error)
@@ -743,12 +743,12 @@ internal struct MockService: ServiceType {
     return .empty
   }
 
-  internal func fetchProjects(paginationUrl paginationUrl: String) ->
+  internal func fetchProjects(paginationUrl: String) ->
     SignalProducer<ProjectsEnvelope, ErrorEnvelope> {
       return fetchProjects(member: true)
   }
 
-  internal func fetchProjectStats(projectId projectId: Int) ->
+  internal func fetchProjectStats(projectId: Int) ->
     SignalProducer<ProjectStatsEnvelope, ErrorEnvelope> {
       if let error = fetchProjectStatsError {
         return SignalProducer(error: error)
@@ -759,7 +759,7 @@ internal struct MockService: ServiceType {
       return SignalProducer(value: .template)
   }
 
-  internal func fetchRewardShippingRules(projectId projectId: Int, rewardId: Int)
+  internal func fetchRewardShippingRules(projectId: Int, rewardId: Int)
     -> SignalProducer<ShippingRulesEnvelope, ErrorEnvelope> {
 
       return .init(value: .init(shippingRules: fetchShippingRulesResponse))
@@ -825,14 +825,14 @@ internal struct MockService: ServiceType {
     return SignalProducer(value: self.fetchUnansweredSurveyResponsesResponse)
   }
 
-  internal func fetchUser(userId userId: Int) -> SignalProducer<User, ErrorEnvelope> {
+  internal func fetchUser(userId: Int) -> SignalProducer<User, ErrorEnvelope> {
     if let error = self.fetchUserError {
       return SignalProducer(error: error)
     }
     return SignalProducer(value: self.fetchUserResponse ?? (.template |> User.lens.id .~ userId))
   }
 
-  internal func fetchUser(user: User) -> SignalProducer<User, ErrorEnvelope> {
+  internal func fetchUser(_ user: User) -> SignalProducer<User, ErrorEnvelope> {
     if let error = self.fetchUserError {
       return SignalProducer(error: error)
     }
@@ -844,7 +844,7 @@ internal struct MockService: ServiceType {
     return SignalProducer(value: self.fetchCategoriesResponse ?? .template)
   }
 
-  internal func fetchCategory(param param: Param) -> SignalProducer<KsApi.Category, ErrorEnvelope> {
+  internal func fetchCategory(param: Param) -> SignalProducer<KsApi.Category, ErrorEnvelope> {
     switch param {
     case let .id(id):
       return SignalProducer(value: .template |> Category.lens.id .~ id)
@@ -871,17 +871,17 @@ internal struct MockService: ServiceType {
       }
   }
 
-  internal func toggleStar(project: Project) -> SignalProducer<StarEnvelope, ErrorEnvelope> {
+  internal func toggleStar(_ project: Project) -> SignalProducer<StarEnvelope, ErrorEnvelope> {
     guard let toggleStarResponse = toggleStarResponse else { return .init(error: .couldNotParseJSON) }
     return .init(value: toggleStarResponse)
   }
 
-  internal func star(project: Project) -> SignalProducer<StarEnvelope, ErrorEnvelope> {
+  internal func star(_ project: Project) -> SignalProducer<StarEnvelope, ErrorEnvelope> {
     let project = project |> Project.lens.personalization.isStarred .~ true
     return .init(value: .template |> StarEnvelope.lens.project .~ project)
   }
 
-  internal func login(email email: String, password: String, code: String?) ->
+  internal func login(email: String, password: String, code: String?) ->
     SignalProducer<AccessTokenEnvelope, ErrorEnvelope> {
 
     if let error = loginError {
@@ -897,7 +897,7 @@ internal struct MockService: ServiceType {
     return SignalProducer(value: AccessTokenEnvelope(accessToken: "deadbeef", user: .template))
   }
 
-  internal func login(facebookAccessToken facebookAccessToken: String, code: String?) ->
+  internal func login(facebookAccessToken: String, code: String?) ->
     SignalProducer<AccessTokenEnvelope, ErrorEnvelope> {
 
     if let error = loginError {
@@ -913,12 +913,12 @@ internal struct MockService: ServiceType {
     return SignalProducer(value: AccessTokenEnvelope(accessToken: "deadbeef", user: .template))
   }
 
-  internal func markAsRead(messageThread messageThread: MessageThread)
+  internal func markAsRead(messageThread: MessageThread)
     -> SignalProducer<MessageThread, ErrorEnvelope> {
       return SignalProducer(value: messageThread)
   }
 
-  internal func postComment(body: String, toProject project: Project) ->
+  internal func postComment(_ body: String, toProject project: Project) ->
     SignalProducer<Comment, ErrorEnvelope> {
 
     if let error = self.postCommentError {
@@ -929,7 +929,7 @@ internal struct MockService: ServiceType {
     return .empty
   }
 
-  func postComment(body: String, toUpdate update: Update) -> SignalProducer<Comment, ErrorEnvelope> {
+  func postComment(_ body: String, toUpdate update: Update) -> SignalProducer<Comment, ErrorEnvelope> {
 
     if let error = self.postCommentError {
       return SignalProducer(error: error)
@@ -939,7 +939,7 @@ internal struct MockService: ServiceType {
     return .empty
   }
 
-  func resetPassword(email email: String) -> SignalProducer<User, ErrorEnvelope> {
+  func resetPassword(email: String) -> SignalProducer<User, ErrorEnvelope> {
     if let response = resetPasswordResponse {
       return SignalProducer(value: response)
     } else if let error = resetPasswordError {
@@ -948,11 +948,11 @@ internal struct MockService: ServiceType {
     return SignalProducer(value: .template)
   }
 
-  func register(pushToken pushToken: String) -> SignalProducer<VoidEnvelope, ErrorEnvelope> {
+  func register(pushToken: String) -> SignalProducer<VoidEnvelope, ErrorEnvelope> {
     return SignalProducer(value: VoidEnvelope())
   }
 
-  internal func searchMessages(query query: String, project: Project?)
+  internal func searchMessages(query: String, project: Project?)
     -> SignalProducer<MessageThreadsEnvelope, ErrorEnvelope> {
       return SignalProducer(value:
         MessageThreadsEnvelope(
@@ -966,7 +966,7 @@ internal struct MockService: ServiceType {
       )
   }
 
-  internal func sendMessage(body body: String, toSubject subject: MessageSubject)
+  internal func sendMessage(body: String, toSubject subject: MessageSubject)
     -> SignalProducer<Message, ErrorEnvelope> {
 
       return SignalProducer(
@@ -976,7 +976,7 @@ internal struct MockService: ServiceType {
       )
   }
 
-  internal func signup(name name: String,
+  internal func signup(name: String,
                           email: String,
                           password: String,
                           passwordConfirmation: String,
@@ -996,7 +996,7 @@ internal struct MockService: ServiceType {
     )
   }
 
-  internal func signup(facebookAccessToken facebookAccessToken: String, sendNewsletters: Bool) ->
+  internal func signup(facebookAccessToken: String, sendNewsletters: Bool) ->
     SignalProducer<AccessTokenEnvelope, ErrorEnvelope> {
 
     if let error = signupError {
@@ -1013,7 +1013,7 @@ internal struct MockService: ServiceType {
   }
 
   func submitApplePay(
-    checkoutUrl checkoutUrl: String,
+    checkoutUrl: String,
                 stripeToken: String,
                 paymentInstrumentName: String,
                 paymentNetwork: String,
@@ -1022,7 +1022,7 @@ internal struct MockService: ServiceType {
     return SignalProducer(value: self.submitApplePayResponse)
   }
 
-  internal func updateProjectNotification(notification: ProjectNotification)
+  internal func updateProjectNotification(_ notification: ProjectNotification)
     -> SignalProducer<ProjectNotification, ErrorEnvelope> {
       if let error = updateProjectNotificationError {
         return SignalProducer(error: error)
@@ -1030,14 +1030,14 @@ internal struct MockService: ServiceType {
       return SignalProducer(value: notification)
   }
 
-  internal func updateUserSelf(user: User) -> SignalProducer<User, ErrorEnvelope> {
+  internal func updateUserSelf(_ user: User) -> SignalProducer<User, ErrorEnvelope> {
     if let error = updateUserSelfError {
       return SignalProducer(error: error)
     }
     return SignalProducer(value: user)
   }
 
-  internal func fetchUpdate(updateId updateId: Int, projectParam: Param)
+  internal func fetchUpdate(updateId: Int, projectParam: Param)
     -> SignalProducer<Update, ErrorEnvelope> {
 
       return SignalProducer(value: self.fetchUpdateResponse |> Update.lens.id .~ updateId)
@@ -1050,7 +1050,7 @@ internal struct MockService: ServiceType {
     return SignalProducer(value: fetchDraftResponse ?? .template)
   }
 
-  internal func update(draft draft: UpdateDraft, title: String, body: String, isPublic: Bool)
+  internal func update(draft: UpdateDraft, title: String, body: String, isPublic: Bool)
     -> SignalProducer<UpdateDraft, ErrorEnvelope> {
 
       if let error = self.updateDraftError {
@@ -1065,7 +1065,7 @@ internal struct MockService: ServiceType {
   }
 
   internal func updatePledge(
-    project project: Project,
+    project: Project,
             amount: Double,
             reward: Reward?,
             shippingLocation: Location?,
@@ -1084,7 +1084,7 @@ internal struct MockService: ServiceType {
       return SignalProducer(value: addAttachmentResponse ?? .template)
   }
 
-  internal func delete(image image: UpdateDraft.Image, fromDraft draft: UpdateDraft)
+  internal func delete(image: UpdateDraft.Image, fromDraft draft: UpdateDraft)
     -> SignalProducer<UpdateDraft.Image, ErrorEnvelope> {
 
       if let error = removeAttachmentError {
@@ -1100,19 +1100,19 @@ internal struct MockService: ServiceType {
       return .empty
   }
 
-  internal func changePaymentMethod(project project: Project)
+  internal func changePaymentMethod(project: Project)
     -> SignalProducer<ChangePaymentMethodEnvelope, ErrorEnvelope> {
 
       return SignalProducer(value: self.changePaymentMethodResponse)
   }
 
-  internal func delete(video video: UpdateDraft.Video, fromDraft draft: UpdateDraft)
+  internal func delete(video: UpdateDraft.Video, fromDraft draft: UpdateDraft)
     -> SignalProducer<UpdateDraft.Video, ErrorEnvelope> {
 
       return .empty
   }
 
-  internal func publish(draft draft: UpdateDraft) -> SignalProducer<Update, ErrorEnvelope> {
+  internal func publish(draft: UpdateDraft) -> SignalProducer<Update, ErrorEnvelope> {
     if let error = publishUpdateError {
       return SignalProducer(error: error)
     }
@@ -1120,8 +1120,8 @@ internal struct MockService: ServiceType {
     return SignalProducer(value: fetchUpdateResponse)
   }
 
-  internal func previewUrl(forDraft draft: UpdateDraft) -> NSURL? {
-    return NSURL(
+  internal func previewUrl(forDraft draft: UpdateDraft) -> URL? {
+    return URL(
       string: "https://\(Secrets.Api.Endpoint.production)/projects/\(draft.update.projectId)/updates/"
         + "\(draft.update.id)/preview"
     )

--- a/KsApi/ServerConfig.swift
+++ b/KsApi/ServerConfig.swift
@@ -2,15 +2,15 @@
  A type that knows the location of a Kickstarter API and web server.
 */
 public protocol ServerConfigType {
-  var apiBaseUrl: NSURL { get }
-  var webBaseUrl: NSURL { get }
+  var apiBaseUrl: URL { get }
+  var webBaseUrl: URL { get }
   var apiClientAuth: ClientAuthType { get }
   var basicHTTPAuth: BasicHTTPAuthType? { get }
 }
 
 public func == (lhs: ServerConfigType, rhs: ServerConfigType) -> Bool {
   return
-    lhs.dynamicType == rhs.dynamicType &&
+    type(of: lhs) == type(of: rhs) &&
     lhs.apiBaseUrl == rhs.apiBaseUrl &&
     lhs.webBaseUrl == rhs.webBaseUrl &&
     lhs.apiClientAuth == rhs.apiClientAuth &&
@@ -18,34 +18,34 @@ public func == (lhs: ServerConfigType, rhs: ServerConfigType) -> Bool {
 }
 
 public struct ServerConfig: ServerConfigType {
-  public let apiBaseUrl: NSURL
-  public let webBaseUrl: NSURL
+  public let apiBaseUrl: URL
+  public let webBaseUrl: URL
   public let apiClientAuth: ClientAuthType
   public let basicHTTPAuth: BasicHTTPAuthType?
 
   public static let production: ServerConfigType = ServerConfig(
-    apiBaseUrl: NSURL(string: "https://\(Secrets.Api.Endpoint.production)")!,
-    webBaseUrl: NSURL(string: "https://\(Secrets.WebEndpoint.production)")!,
+    apiBaseUrl: URL(string: "https://\(Secrets.Api.Endpoint.production)")!,
+    webBaseUrl: URL(string: "https://\(Secrets.WebEndpoint.production)")!,
     apiClientAuth: ClientAuth.production,
     basicHTTPAuth: nil
   )
 
   public static let staging: ServerConfigType = ServerConfig(
-    apiBaseUrl: NSURL(string: "https://\(Secrets.Api.Endpoint.staging)")!,
-    webBaseUrl: NSURL(string: "https://\(Secrets.WebEndpoint.staging)")!,
+    apiBaseUrl: URL(string: "https://\(Secrets.Api.Endpoint.staging)")!,
+    webBaseUrl: URL(string: "https://\(Secrets.WebEndpoint.staging)")!,
     apiClientAuth: ClientAuth.development,
     basicHTTPAuth: BasicHTTPAuth.development
   )
 
   public static let local: ServerConfigType = ServerConfig(
-    apiBaseUrl: NSURL(string: "http://api.ksr.dev")!,
-    webBaseUrl: NSURL(string: "http://ksr.dev")!,
+    apiBaseUrl: URL(string: "http://api.ksr.dev")!,
+    webBaseUrl: URL(string: "http://ksr.dev")!,
     apiClientAuth: ClientAuth.development,
     basicHTTPAuth: BasicHTTPAuth.development
   )
 
-  public init(apiBaseUrl: NSURL,
-              webBaseUrl: NSURL,
+  public init(apiBaseUrl: URL,
+              webBaseUrl: URL,
               apiClientAuth: ClientAuthType,
               basicHTTPAuth: BasicHTTPAuthType?) {
 

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -4,8 +4,8 @@
 import Argo
 import Foundation
 import Prelude
-import ReactiveSwift
 import ReactiveExtensions
+import ReactiveSwift
 
 private extension Bundle {
   var _buildVersion: String {

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -436,12 +436,11 @@ public struct Service: ServiceType {
       return request(.updateUpdateDraft(draft, title: title, body: body, isPublic: isPublic))
   }
 
-  public func updatePledge(
-    project: Project,
-            amount: Double,
-            reward: Reward?,
-            shippingLocation: Location?,
-            tappedReward: Bool) -> SignalProducer<UpdatePledgeEnvelope, ErrorEnvelope> {
+  public func updatePledge(project: Project,
+                           amount: Double,
+                           reward: Reward?,
+                           shippingLocation: Location?,
+                           tappedReward: Bool) -> SignalProducer<UpdatePledgeEnvelope, ErrorEnvelope> {
 
     return request(
       .updatePledge(
@@ -464,7 +463,7 @@ public struct Service: ServiceType {
     return request(.updateUserSelf(user))
   }
 
-  fileprivate func decodeModel<M: Decodable>(_ json: AnyObject) ->
+  private func decodeModel<M: Decodable>(_ json: AnyObject) ->
     SignalProducer<M, ErrorEnvelope> where M == M.DecodedType {
 
       return SignalProducer(value: json)
@@ -480,7 +479,7 @@ public struct Service: ServiceType {
       }
   }
 
-  fileprivate func decodeModels<M: Decodable>(_ json: AnyObject) ->
+  private func decodeModels<M: Decodable>(_ json: AnyObject) ->
     SignalProducer<[M], ErrorEnvelope> where M == M.DecodedType {
 
       return SignalProducer(value: json)
@@ -496,9 +495,9 @@ public struct Service: ServiceType {
       }
   }
 
-  fileprivate static let session = URLSession(configuration: .default)
+  private static let session = URLSession(configuration: .default)
 
-  fileprivate func requestPagination<M: Decodable>(_ paginationUrl: String)
+  private func requestPagination<M: Decodable>(_ paginationUrl: String)
     -> SignalProducer<M, ErrorEnvelope> where M == M.DecodedType {
 
       guard let paginationUrl = URL(string: paginationUrl) else {
@@ -509,7 +508,7 @@ public struct Service: ServiceType {
         .flatMap(decodeModel)
   }
 
-  fileprivate func request<M: Decodable>(_ route: Route)
+  private func request<M: Decodable>(_ route: Route)
     -> SignalProducer<M, ErrorEnvelope> where M == M.DecodedType {
 
       let properties = route.requestProperties
@@ -527,15 +526,15 @@ public struct Service: ServiceType {
         .flatMap(decodeModel)
   }
 
-  fileprivate func request<M: Decodable>(_ route: Route)
+  private func request<M: Decodable>(_ route: Route)
     -> SignalProducer<[M], ErrorEnvelope> where M == M.DecodedType {
 
       let properties = route.requestProperties
 
-      let URL = self.serverConfig.apiBaseUrl.appendingPathComponent(properties.path)
+      let url = self.serverConfig.apiBaseUrl.appendingPathComponent(properties.path)
 
       return Service.session.rac_JSONResponse(
-        preparedRequest(forURL: URL, method: properties.method, query: properties.query),
+        preparedRequest(forURL: url, method: properties.method, query: properties.query),
         uploading: properties.file.map { ($1, $0.rawValue) }
         )
         .flatMap(decodeModels)

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -463,7 +463,7 @@ public struct Service: ServiceType {
     return request(.updateUserSelf(user))
   }
 
-  private func decodeModel<M: Decodable>(_ json: AnyObject) ->
+  private func decodeModel<M: Decodable>(_ json: Any) ->
     SignalProducer<M, ErrorEnvelope> where M == M.DecodedType {
 
       return SignalProducer(value: json)
@@ -479,7 +479,7 @@ public struct Service: ServiceType {
       }
   }
 
-  private func decodeModels<M: Decodable>(_ json: AnyObject) ->
+  private func decodeModels<M: Decodable>(_ json: Any) ->
     SignalProducer<[M], ErrorEnvelope> where M == M.DecodedType {
 
       return SignalProducer(value: json)

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -7,7 +7,7 @@ import Prelude
 import ReactiveCocoa
 import ReactiveExtensions
 
-private extension NSBundle {
+private extension Bundle {
   var _buildVersion: String {
     return (self.infoDictionary?["CFBundleVersion"] as? String) ?? "1"
   }
@@ -23,11 +23,11 @@ public struct Service: ServiceType {
   public let language: String
   public let buildVersion: String
 
-  public init(appId: String = NSBundle.mainBundle().bundleIdentifier ?? "com.kickstarter.kickstarter",
+  public init(appId: String = Bundle.main.bundleIdentifier ?? "com.kickstarter.kickstarter",
               serverConfig: ServerConfigType = ServerConfig.production,
               oauthToken: OauthTokenAuthType? = nil,
               language: String = "en",
-              buildVersion: String = NSBundle.mainBundle()._buildVersion) {
+              buildVersion: String = Bundle.main._buildVersion) {
 
     self.appId = appId
     self.serverConfig = serverConfig
@@ -36,7 +36,7 @@ public struct Service: ServiceType {
     self.buildVersion = buildVersion
   }
 
-  public func login(oauthToken: OauthTokenAuthType) -> Service {
+  public func login(_ oauthToken: OauthTokenAuthType) -> Service {
     return Service(appId: self.appId,
                    serverConfig: self.serverConfig,
                    oauthToken: oauthToken,
@@ -68,13 +68,13 @@ public struct Service: ServiceType {
       return request(Route.addVideo(fileUrl: fileURL, toDraft: draft))
   }
 
-  public func changePaymentMethod(project project: Project)
+  public func changePaymentMethod(project: Project)
     -> SignalProducer<ChangePaymentMethodEnvelope, ErrorEnvelope> {
 
       return request(.changePaymentMethod(project: project))
   }
 
-  public func createPledge(project project: Project,
+  public func createPledge(project: Project,
                            amount: Double,
                            reward: Reward?,
                            shippingLocation: Location?,
@@ -90,24 +90,24 @@ public struct Service: ServiceType {
     )
   }
 
-  public func delete(image image: UpdateDraft.Image, fromDraft draft: UpdateDraft)
+  public func delete(image: UpdateDraft.Image, fromDraft draft: UpdateDraft)
     -> SignalProducer<UpdateDraft.Image, ErrorEnvelope> {
 
       return request(.deleteImage(image, fromDraft: draft))
   }
 
-  public func delete(video video: UpdateDraft.Video, fromDraft draft: UpdateDraft)
+  public func delete(video: UpdateDraft.Video, fromDraft draft: UpdateDraft)
     -> SignalProducer<UpdateDraft.Video, ErrorEnvelope> {
 
       return request(.deleteVideo(video, fromDraft: draft))
   }
 
-  public func previewUrl(forDraft draft: UpdateDraft) -> NSURL? {
+  public func previewUrl(forDraft draft: UpdateDraft) -> URL? {
     return self.serverConfig.apiBaseUrl
-      .URLByAppendingPathComponent("/v1/projects/\(draft.update.projectId)/updates/draft/preview")
+      .appendingPathComponent("/v1/projects/\(draft.update.projectId)/updates/draft/preview")
   }
 
-  public func fetchActivities(count count: Int?) -> SignalProducer<ActivityEnvelope, ErrorEnvelope> {
+  public func fetchActivities(count: Int?) -> SignalProducer<ActivityEnvelope, ErrorEnvelope> {
     let categories: [Activity.Category] = [
       .backing,
       .cancellation,
@@ -120,7 +120,7 @@ public struct Service: ServiceType {
     return request(.activities(categories: categories, count: count))
   }
 
-  public func fetchActivities(paginationUrl paginationUrl: String)
+  public func fetchActivities(paginationUrl: String)
     -> SignalProducer<ActivityEnvelope, ErrorEnvelope> {
       return requestPagination(paginationUrl)
   }
@@ -134,7 +134,7 @@ public struct Service: ServiceType {
     return request(.categories)
   }
 
-  public func fetchCategory(param param: Param) -> SignalProducer<Category, ErrorEnvelope> {
+  public func fetchCategory(param: Param) -> SignalProducer<Category, ErrorEnvelope> {
     return request(.category(param))
   }
 
@@ -146,11 +146,11 @@ public struct Service: ServiceType {
     return requestPagination(url)
   }
 
-  public func fetchComments(project project: Project) -> SignalProducer<CommentsEnvelope, ErrorEnvelope> {
+  public func fetchComments(project: Project) -> SignalProducer<CommentsEnvelope, ErrorEnvelope> {
     return request(.projectComments(project))
   }
 
-  public func fetchComments(update update: Update) -> SignalProducer<CommentsEnvelope, ErrorEnvelope> {
+  public func fetchComments(update: Update) -> SignalProducer<CommentsEnvelope, ErrorEnvelope> {
     return request(.updateComments(update))
   }
 
@@ -158,13 +158,13 @@ public struct Service: ServiceType {
     return request(.config)
   }
 
-  public func fetchDiscovery(paginationUrl paginationUrl: String)
+  public func fetchDiscovery(paginationUrl: String)
     -> SignalProducer<DiscoveryEnvelope, ErrorEnvelope> {
 
     return requestPagination(paginationUrl)
   }
 
-  public func fetchDiscovery(params params: DiscoveryParams)
+  public func fetchDiscovery(params: DiscoveryParams)
     -> SignalProducer<DiscoveryEnvelope, ErrorEnvelope> {
 
     return request(.discover(params))
@@ -174,7 +174,7 @@ public struct Service: ServiceType {
     return request(.friends)
   }
 
-  public func fetchFriends(paginationUrl paginationUrl: String)
+  public func fetchFriends(paginationUrl: String)
     -> SignalProducer<FindFriendsEnvelope, ErrorEnvelope> {
 
       return requestPagination(paginationUrl)
@@ -184,38 +184,38 @@ public struct Service: ServiceType {
     return request(.friendStats)
   }
 
-  public func fetchMessageThread(messageThreadId messageThreadId: Int)
+  public func fetchMessageThread(messageThreadId: Int)
     -> SignalProducer<MessageThreadEnvelope, ErrorEnvelope> {
 
       return request(.messagesForThread(messageThreadId: messageThreadId))
   }
 
-  public func fetchMessageThread(backing backing: Backing)
+  public func fetchMessageThread(backing: Backing)
     -> SignalProducer<MessageThreadEnvelope, ErrorEnvelope> {
     return request(.messagesForBacking(backing))
   }
 
-  public func fetchMessageThreads(mailbox mailbox: Mailbox, project: Project?)
+  public func fetchMessageThreads(mailbox: Mailbox, project: Project?)
     -> SignalProducer<MessageThreadsEnvelope, ErrorEnvelope> {
 
       return request(.messageThreads(mailbox: mailbox, project: project))
   }
 
-  public func fetchMessageThreads(paginationUrl paginationUrl: String)
+  public func fetchMessageThreads(paginationUrl: String)
     -> SignalProducer<MessageThreadsEnvelope, ErrorEnvelope> {
 
       return requestPagination(paginationUrl)
   }
 
-  public func fetchProject(param param: Param) -> SignalProducer<Project, ErrorEnvelope> {
+  public func fetchProject(param: Param) -> SignalProducer<Project, ErrorEnvelope> {
     return request(.project(param))
   }
 
-  public func fetchProject(params: DiscoveryParams) -> SignalProducer<DiscoveryEnvelope, ErrorEnvelope> {
+  public func fetchProject(_ params: DiscoveryParams) -> SignalProducer<DiscoveryEnvelope, ErrorEnvelope> {
     return request(.discover(params |> DiscoveryParams.lens.perPage .~ 1))
   }
 
-  public func fetchProject(project project: Project) -> SignalProducer<Project, ErrorEnvelope> {
+  public func fetchProject(project: Project) -> SignalProducer<Project, ErrorEnvelope> {
     return request(.project(.id(project.id)))
   }
 
@@ -228,12 +228,12 @@ public struct Service: ServiceType {
       return request(.projectActivities(project))
   }
 
-  public func fetchProjectActivities(paginationUrl paginationUrl: String)
+  public func fetchProjectActivities(paginationUrl: String)
     -> SignalProducer<ProjectActivityEnvelope, ErrorEnvelope> {
       return requestPagination(paginationUrl)
   }
 
-  public func fetchProjects(member member: Bool) -> SignalProducer<ProjectsEnvelope, ErrorEnvelope> {
+  public func fetchProjects(member: Bool) -> SignalProducer<ProjectsEnvelope, ErrorEnvelope> {
     return request(.projects(member: member))
   }
 
@@ -241,12 +241,12 @@ public struct Service: ServiceType {
     return requestPagination(url)
   }
 
-  public func fetchProjectStats(projectId projectId: Int) ->
+  public func fetchProjectStats(projectId: Int) ->
     SignalProducer<ProjectStatsEnvelope, ErrorEnvelope> {
       return request(.projectStats(projectId: projectId))
   }
 
-  public func fetchRewardShippingRules(projectId projectId: Int, rewardId: Int)
+  public func fetchRewardShippingRules(projectId: Int, rewardId: Int)
     -> SignalProducer<ShippingRulesEnvelope, ErrorEnvelope> {
       return request(.shippingRules(projectId: projectId, rewardId: rewardId))
   }
@@ -268,15 +268,15 @@ public struct Service: ServiceType {
     return request(.userSelf)
   }
 
-  public func fetchUser(userId userId: Int) -> SignalProducer<User, ErrorEnvelope> {
+  public func fetchUser(userId: Int) -> SignalProducer<User, ErrorEnvelope> {
     return request(.user(userId: userId))
   }
 
-  public func fetchUser(user: User) -> SignalProducer<User, ErrorEnvelope> {
+  public func fetchUser(_ user: User) -> SignalProducer<User, ErrorEnvelope> {
     return fetchUser(userId: user.id)
   }
 
-  public func fetchUpdate(updateId updateId: Int, projectParam: Param)
+  public func fetchUpdate(updateId: Int, projectParam: Param)
     -> SignalProducer<Update, ErrorEnvelope> {
 
       return request(.update(updateId: updateId, projectParam: projectParam))
@@ -328,61 +328,61 @@ public struct Service: ServiceType {
       }
   }
 
-  public func login(email email: String, password: String, code: String?) ->
+  public func login(email: String, password: String, code: String?) ->
     SignalProducer<AccessTokenEnvelope, ErrorEnvelope> {
 
     return request(.login(email: email, password: password, code: code))
   }
 
-  public func login(facebookAccessToken facebookAccessToken: String, code: String?) ->
+  public func login(facebookAccessToken: String, code: String?) ->
     SignalProducer<AccessTokenEnvelope, ErrorEnvelope> {
 
     return request(.facebookLogin(facebookAccessToken: facebookAccessToken, code: code))
   }
 
-  public func markAsRead(messageThread messageThread: MessageThread)
+  public func markAsRead(messageThread: MessageThread)
     -> SignalProducer<MessageThread, ErrorEnvelope> {
 
       return request(.markAsRead(messageThread))
   }
 
-  public func postComment(body: String, toProject project: Project) ->
+  public func postComment(_ body: String, toProject project: Project) ->
     SignalProducer<Comment, ErrorEnvelope> {
 
       return request(.postProjectComment(project, body: body))
   }
 
-  public func postComment(body: String, toUpdate update: Update) -> SignalProducer<Comment, ErrorEnvelope> {
+  public func postComment(_ body: String, toUpdate update: Update) -> SignalProducer<Comment, ErrorEnvelope> {
 
       return request(.postUpdateComment(update, body: body))
   }
 
-  public func publish(draft draft: UpdateDraft) -> SignalProducer<Update, ErrorEnvelope> {
+  public func publish(draft: UpdateDraft) -> SignalProducer<Update, ErrorEnvelope> {
     return request(.publishUpdateDraft(draft))
   }
 
-  public func register(pushToken pushToken: String) -> SignalProducer<VoidEnvelope, ErrorEnvelope> {
+  public func register(pushToken: String) -> SignalProducer<VoidEnvelope, ErrorEnvelope> {
 
     return request(.registerPushToken(pushToken))
   }
 
-  public func resetPassword(email email: String) -> SignalProducer<User, ErrorEnvelope> {
+  public func resetPassword(email: String) -> SignalProducer<User, ErrorEnvelope> {
     return request(.resetPassword(email: email))
   }
 
-  public func searchMessages(query query: String, project: Project?)
+  public func searchMessages(query: String, project: Project?)
     -> SignalProducer<MessageThreadsEnvelope, ErrorEnvelope> {
 
       return request(.searchMessages(query: query, project: project))
   }
 
-  public func sendMessage(body body: String, toSubject subject: MessageSubject)
+  public func sendMessage(body: String, toSubject subject: MessageSubject)
     -> SignalProducer<Message, ErrorEnvelope> {
 
       return request(.sendMessage(body: body, messageSubject: subject))
   }
 
-  public func signup(name name: String,
+  public func signup(name: String,
                           email: String,
                           password: String,
                           passwordConfirmation: String,
@@ -400,12 +400,12 @@ public struct Service: ServiceType {
     return request(.facebookSignup(facebookAccessToken: token, sendNewsletters: sendNewsletters))
   }
 
-  public func star(project: Project) -> SignalProducer<StarEnvelope, ErrorEnvelope> {
+  public func star(_ project: Project) -> SignalProducer<StarEnvelope, ErrorEnvelope> {
     return request(.star(project))
   }
 
   public func submitApplePay(
-    checkoutUrl checkoutUrl: String,
+    checkoutUrl: String,
                 stripeToken: String,
                 paymentInstrumentName: String,
                 paymentNetwork: String,
@@ -422,7 +422,7 @@ public struct Service: ServiceType {
     )
   }
 
-  public func toggleStar(project: Project) -> SignalProducer<StarEnvelope, ErrorEnvelope> {
+  public func toggleStar(_ project: Project) -> SignalProducer<StarEnvelope, ErrorEnvelope> {
     return request(.toggleStar(project))
   }
 
@@ -430,14 +430,14 @@ public struct Service: ServiceType {
     return request(.unfollowFriend(userId: id))
   }
 
-  public func update(draft draft: UpdateDraft, title: String, body: String, isPublic: Bool)
+  public func update(draft: UpdateDraft, title: String, body: String, isPublic: Bool)
     -> SignalProducer<UpdateDraft, ErrorEnvelope> {
 
       return request(.updateUpdateDraft(draft, title: title, body: body, isPublic: isPublic))
   }
 
   public func updatePledge(
-    project project: Project,
+    project: Project,
             amount: Double,
             reward: Reward?,
             shippingLocation: Location?,
@@ -454,18 +454,18 @@ public struct Service: ServiceType {
     )
   }
 
-  public func updateProjectNotification(notification: ProjectNotification)
+  public func updateProjectNotification(_ notification: ProjectNotification)
     -> SignalProducer<ProjectNotification, ErrorEnvelope> {
 
     return request(.updateProjectNotification(notification: notification))
   }
 
-  public func updateUserSelf(user: User) -> SignalProducer<User, ErrorEnvelope> {
+  public func updateUserSelf(_ user: User) -> SignalProducer<User, ErrorEnvelope> {
     return request(.updateUserSelf(user))
   }
 
-  private func decodeModel<M: Decodable where M == M.DecodedType>(json: AnyObject) ->
-    SignalProducer<M, ErrorEnvelope> {
+  fileprivate func decodeModel<M: Decodable>(_ json: AnyObject) ->
+    SignalProducer<M, ErrorEnvelope> where M == M.DecodedType {
 
       return SignalProducer(value: json)
         .map { json in decode(json) as Decoded<M> }
@@ -480,8 +480,8 @@ public struct Service: ServiceType {
       }
   }
 
-  private func decodeModels<M: Decodable where M == M.DecodedType>(json: AnyObject) ->
-    SignalProducer<[M], ErrorEnvelope> {
+  fileprivate func decodeModels<M: Decodable>(_ json: AnyObject) ->
+    SignalProducer<[M], ErrorEnvelope> where M == M.DecodedType {
 
       return SignalProducer(value: json)
         .map { json in decode(json) as Decoded<[M]> }
@@ -496,12 +496,12 @@ public struct Service: ServiceType {
       }
   }
 
-  private static let session = NSURLSession(configuration: .defaultSessionConfiguration())
+  fileprivate static let session = URLSession(configuration: .default)
 
-  private func requestPagination<M: Decodable where M == M.DecodedType>(paginationUrl: String)
-    -> SignalProducer<M, ErrorEnvelope> {
+  fileprivate func requestPagination<M: Decodable>(_ paginationUrl: String)
+    -> SignalProducer<M, ErrorEnvelope> where M == M.DecodedType {
 
-      guard let paginationUrl = NSURL(string: paginationUrl) else {
+      guard let paginationUrl = URL(string: paginationUrl) else {
         return .init(error: .invalidPaginationUrl)
       }
 
@@ -509,12 +509,12 @@ public struct Service: ServiceType {
         .flatMap(decodeModel)
   }
 
-  private func request<M: Decodable where M == M.DecodedType>(route: Route)
-    -> SignalProducer<M, ErrorEnvelope> {
+  fileprivate func request<M: Decodable>(_ route: Route)
+    -> SignalProducer<M, ErrorEnvelope> where M == M.DecodedType {
 
       let properties = route.requestProperties
 
-      guard let URL = NSURL(string: properties.path, relativeToURL: self.serverConfig.apiBaseUrl) else {
+      guard let URL = URL(string: properties.path, relativeTo: self.serverConfig.apiBaseUrl as URL) else {
         fatalError(
           "NSURL(string: \(properties.path), relativeToURL: \(self.serverConfig.apiBaseUrl)) == nil"
         )
@@ -527,8 +527,8 @@ public struct Service: ServiceType {
         .flatMap(decodeModel)
   }
 
-  private func request<M: Decodable where M == M.DecodedType>(route: Route)
-    -> SignalProducer<[M], ErrorEnvelope> {
+  fileprivate func request<M: Decodable>(_ route: Route)
+    -> SignalProducer<[M], ErrorEnvelope> where M == M.DecodedType {
 
       let properties = route.requestProperties
 

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -369,10 +369,10 @@ extension ServiceType {
     headers["Kickstarter-App-Id"] = self.appId
     headers["Kickstarter-iOS-App"] = self.buildVersion
 
-    let executable = Bundle.main.infoDictionary?["CFBundleExecutable"]
-    let bundleIdentifier = Bundle.main.infoDictionary?["CFBundleIdentifier"]
-    let app: AnyObject = (executable as AnyObject?? ?? bundleIdentifier as AnyObject?) ?? "Kickstarter" as AnyObject
-    let bundleVersion: AnyObject = Bundle.main.infoDictionary?["CFBundleVersion"] as AnyObject? ?? "1" as AnyObject
+    let executable = Bundle.main.infoDictionary?["CFBundleExecutable"] as? String
+    let bundleIdentifier = Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String
+    let app: String = executable ?? bundleIdentifier ?? "Kickstarter"
+    let bundleVersion: String = (Bundle.main.infoDictionary?["CFBundleVersion"] as? String) ?? "1"
     let model = UIDevice.current.model
     let systemVersion = UIDevice.current.systemVersion
     let scale = UIScreen.main.scale

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable file_length
 import Foundation
 import Prelude
-import ReactiveCocoa
+import ReactiveSwift
 
 public enum Mailbox: String {
   case inbox
@@ -302,7 +302,7 @@ extension ServiceType {
 
    - returns: A new URL request that is properly configured for the server.
    */
-  public func preparedRequest(forRequest originalRequest: URLRequest, query: [String:AnyObject] = [:])
+  public func preparedRequest(forRequest originalRequest: URLRequest, query: [String:Any] = [:])
     -> URLRequest {
 
       guard let request = (originalRequest as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
@@ -325,11 +325,11 @@ extension ServiceType {
           request.httpBody = try? JSONSerialization.data(withJSONObject: query, options: [])
         }
       } else {
-        queryItems.append(
-          contentsOf: query
-            .flatMap(queryComponents)
-            .map(URLQueryItem.init(name:value:))
-        )
+        let __test__ = query
+          .flatMap(queryComponents)
+          .map(URLQueryItem.init(name:value:))
+
+        queryItems.append(contentsOf: __test__)
       }
       components.queryItems = queryItems.sorted { $0.name < $1.name }
       request.url = components.url
@@ -349,7 +349,7 @@ extension ServiceType {
 
    - returns: A new URL request that is properly configured for the server.
    */
-  public func preparedRequest(forURL URL: Foundation.URL, method: Method = .GET, query: [String:AnyObject] = [:])
+  public func preparedRequest(forURL URL: Foundation.URL, method: Method = .GET, query: [String:Any] = [:])
     -> URLRequest {
 
       let request = NSMutableURLRequest(url: URL)
@@ -397,14 +397,14 @@ extension ServiceType {
     return query
   }
 
-  fileprivate func queryComponents(_ key: String, _ value: AnyObject) -> [(String, String)] {
+  fileprivate func queryComponents(_ key: String, _ value: Any) -> [(String, String)] {
     var components: [(String, String)] = []
 
-    if let dictionary = value as? [String: AnyObject] {
+    if let dictionary = value as? [String:Any] {
       for (nestedKey, value) in dictionary {
         components += queryComponents("\(key)[\(nestedKey)]", value)
       }
-    } else if let array = value as? [AnyObject] {
+    } else if let array = value as? [Any] {
       for value in array {
         components += queryComponents("\(key)[]", value)
       }

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -25,7 +25,7 @@ public protocol ServiceType {
        buildVersion: String)
 
   /// Returns a new service with the oauth token replaced.
-  func login(oauthToken: OauthTokenAuthType) -> Self
+  func login(_ oauthToken: OauthTokenAuthType) -> Self
 
   /// Returns a new service with the oauth token set to `nil`.
   func logout() -> Self
@@ -34,36 +34,36 @@ public protocol ServiceType {
   func facebookConnect(facebookAccessToken token: String) -> SignalProducer<User, ErrorEnvelope>
 
   /// Uploads and attaches an image to the draft of a project update.
-  func addImage(file fileURL: NSURL, toDraft draft: UpdateDraft)
+  func addImage(file fileURL: URL, toDraft draft: UpdateDraft)
     -> SignalProducer<UpdateDraft.Image, ErrorEnvelope>
 
   /// Uploads and attaches a video to the draft of a project update.
-  func addVideo(file fileURL: NSURL, toDraft draft: UpdateDraft)
+  func addVideo(file fileURL: URL, toDraft draft: UpdateDraft)
     -> SignalProducer<UpdateDraft.Video, ErrorEnvelope>
 
-  func changePaymentMethod(project project: Project)
+  func changePaymentMethod(project: Project)
     -> SignalProducer<ChangePaymentMethodEnvelope, ErrorEnvelope>
 
   /// Performs the first step of checkout by creating a pledge on the server.
-  func createPledge(project project: Project,
+  func createPledge(project: Project,
                     amount: Double,
                     reward: Reward?,
                     shippingLocation: Location?,
                     tappedReward: Bool) -> SignalProducer<CreatePledgeEnvelope, ErrorEnvelope>
 
   /// Removes an image from a project update draft.
-  func delete(image image: UpdateDraft.Image, fromDraft draft: UpdateDraft)
+  func delete(image: UpdateDraft.Image, fromDraft draft: UpdateDraft)
     -> SignalProducer<UpdateDraft.Image, ErrorEnvelope>
 
   /// Removes a video from a project update draft.
-  func delete(video video: UpdateDraft.Video, fromDraft draft: UpdateDraft)
+  func delete(video: UpdateDraft.Video, fromDraft draft: UpdateDraft)
     -> SignalProducer<UpdateDraft.Video, ErrorEnvelope>
 
   /// Fetch a page of activities.
-  func fetchActivities(count count: Int?) -> SignalProducer<ActivityEnvelope, ErrorEnvelope>
+  func fetchActivities(count: Int?) -> SignalProducer<ActivityEnvelope, ErrorEnvelope>
 
   /// Fetch activities from a pagination URL
-  func fetchActivities(paginationUrl paginationUrl: String) -> SignalProducer<ActivityEnvelope, ErrorEnvelope>
+  func fetchActivities(paginationUrl: String) -> SignalProducer<ActivityEnvelope, ErrorEnvelope>
 
   /// Fetches the current user's backing for the project, if it exists.
   func fetchBacking(forProject project: Project, forUser user: User)
@@ -73,7 +73,7 @@ public protocol ServiceType {
   func fetchCategories() -> SignalProducer<CategoriesEnvelope, ErrorEnvelope>
 
   /// Fetch the newest data for a particular category.
-  func fetchCategory(param param: Param) -> SignalProducer<Category, ErrorEnvelope>
+  func fetchCategory(param: Param) -> SignalProducer<Category, ErrorEnvelope>
 
   /// Fetch a checkout's status.
   func fetchCheckout(checkoutUrl url: String) -> SignalProducer<CheckoutEnvelope, ErrorEnvelope>
@@ -82,86 +82,86 @@ public protocol ServiceType {
   func fetchComments(paginationUrl url: String) -> SignalProducer<CommentsEnvelope, ErrorEnvelope>
 
   /// Fetch comments for a project.
-  func fetchComments(project project: Project) -> SignalProducer<CommentsEnvelope, ErrorEnvelope>
+  func fetchComments(project: Project) -> SignalProducer<CommentsEnvelope, ErrorEnvelope>
 
   /// Fetch comments for an update.
-  func fetchComments(update update: Update) -> SignalProducer<CommentsEnvelope, ErrorEnvelope>
+  func fetchComments(update: Update) -> SignalProducer<CommentsEnvelope, ErrorEnvelope>
 
   /// Fetch the config.
   func fetchConfig() -> SignalProducer<Config, ErrorEnvelope>
 
   /// Fetch discovery envelope with a pagination url.
-  func fetchDiscovery(paginationUrl paginationUrl: String) -> SignalProducer<DiscoveryEnvelope, ErrorEnvelope>
+  func fetchDiscovery(paginationUrl: String) -> SignalProducer<DiscoveryEnvelope, ErrorEnvelope>
 
   /// Fetch the full discovery envelope with specified discovery params.
-  func fetchDiscovery(params params: DiscoveryParams) -> SignalProducer<DiscoveryEnvelope, ErrorEnvelope>
+  func fetchDiscovery(params: DiscoveryParams) -> SignalProducer<DiscoveryEnvelope, ErrorEnvelope>
 
   /// Fetch friends for a user.
   func fetchFriends() -> SignalProducer<FindFriendsEnvelope, ErrorEnvelope>
 
   /// Fetch friends from a pagination url.
-  func fetchFriends(paginationUrl paginationUrl: String) -> SignalProducer<FindFriendsEnvelope, ErrorEnvelope>
+  func fetchFriends(paginationUrl: String) -> SignalProducer<FindFriendsEnvelope, ErrorEnvelope>
 
   /// Fetch friend stats.
   func fetchFriendStats() -> SignalProducer<FriendStatsEnvelope, ErrorEnvelope>
 
   /// Fetches all of the messages in a particular message thread.
-  func fetchMessageThread(messageThreadId messageThreadId: Int)
+  func fetchMessageThread(messageThreadId: Int)
     -> SignalProducer<MessageThreadEnvelope, ErrorEnvelope>
 
   /// Fetches all of the messages related to a particular backing.
-  func fetchMessageThread(backing backing: Backing) -> SignalProducer<MessageThreadEnvelope, ErrorEnvelope>
+  func fetchMessageThread(backing: Backing) -> SignalProducer<MessageThreadEnvelope, ErrorEnvelope>
 
   /// Fetches all of the messages in a particular mailbox and specific to a particular project.
-  func fetchMessageThreads(mailbox mailbox: Mailbox, project: Project?)
+  func fetchMessageThreads(mailbox: Mailbox, project: Project?)
     -> SignalProducer<MessageThreadsEnvelope, ErrorEnvelope>
 
   /// Fetches more messages threads from a pagination URL.
-  func fetchMessageThreads(paginationUrl paginationUrl: String)
+  func fetchMessageThreads(paginationUrl: String)
     -> SignalProducer<MessageThreadsEnvelope, ErrorEnvelope>
 
   /// Fetch the newest data for a particular project from its id.
-  func fetchProject(param param: Param) -> SignalProducer<Project, ErrorEnvelope>
+  func fetchProject(param: Param) -> SignalProducer<Project, ErrorEnvelope>
 
   /// Fetch a single project with the specified discovery params.
-  func fetchProject(params: DiscoveryParams) -> SignalProducer<DiscoveryEnvelope, ErrorEnvelope>
+  func fetchProject(_ params: DiscoveryParams) -> SignalProducer<DiscoveryEnvelope, ErrorEnvelope>
 
   /// Fetch the newest data for a particular project from its project value.
-  func fetchProject(project project: Project) -> SignalProducer<Project, ErrorEnvelope>
+  func fetchProject(project: Project) -> SignalProducer<Project, ErrorEnvelope>
 
   /// Fetch a page of activities for a project.
   func fetchProjectActivities(forProject project: Project) ->
     SignalProducer<ProjectActivityEnvelope, ErrorEnvelope>
 
   /// Fetch a page of activities for a project from a pagination url.
-  func fetchProjectActivities(paginationUrl paginationUrl: String) ->
+  func fetchProjectActivities(paginationUrl: String) ->
     SignalProducer<ProjectActivityEnvelope, ErrorEnvelope>
 
   /// Fetch the user's project notifications.
   func fetchProjectNotifications() -> SignalProducer<[ProjectNotification], ErrorEnvelope>
 
   /// Fetches the projects that the current user is a member of.
-  func fetchProjects(member member: Bool) -> SignalProducer<ProjectsEnvelope, ErrorEnvelope>
+  func fetchProjects(member: Bool) -> SignalProducer<ProjectsEnvelope, ErrorEnvelope>
 
   /// Fetches more projects from a pagination URL.
-  func fetchProjects(paginationUrl paginationUrl: String) -> SignalProducer<ProjectsEnvelope, ErrorEnvelope>
+  func fetchProjects(paginationUrl: String) -> SignalProducer<ProjectsEnvelope, ErrorEnvelope>
 
   /// Fetches the stats for a particular project.
-  func fetchProjectStats(projectId projectId: Int) -> SignalProducer<ProjectStatsEnvelope, ErrorEnvelope>
+  func fetchProjectStats(projectId: Int) -> SignalProducer<ProjectStatsEnvelope, ErrorEnvelope>
 
   /// Fetches a reward for a project and reward id.
-  func fetchRewardShippingRules(projectId projectId: Int, rewardId: Int)
+  func fetchRewardShippingRules(projectId: Int, rewardId: Int)
     -> SignalProducer<ShippingRulesEnvelope, ErrorEnvelope>
 
   /// Fetches a survey response belonging to the current user.
-  func fetchSurveyResponse(surveyResponseId surveyResponseId: Int)
+  func fetchSurveyResponse(surveyResponseId: Int)
     -> SignalProducer<SurveyResponse, ErrorEnvelope>
 
   /// Fetches all of the user's unanswered surveys.
   func fetchUnansweredSurveyResponses() -> SignalProducer<[SurveyResponse], ErrorEnvelope>
 
   /// Fetches an update from its id and project.
-  func fetchUpdate(updateId updateId: Int, projectParam: Param) -> SignalProducer<Update, ErrorEnvelope>
+  func fetchUpdate(updateId: Int, projectParam: Param) -> SignalProducer<Update, ErrorEnvelope>
 
   /// Fetches a project update draft.
   func fetchUpdateDraft(forProject project: Project) -> SignalProducer<UpdateDraft, ErrorEnvelope>
@@ -173,10 +173,10 @@ public protocol ServiceType {
   func fetchUserProjectsBacked(paginationUrl url: String) -> SignalProducer<ProjectsEnvelope, ErrorEnvelope>
 
   /// Fetch the newest data for a particular user.
-  func fetchUser(user: User) -> SignalProducer<User, ErrorEnvelope>
+  func fetchUser(_ user: User) -> SignalProducer<User, ErrorEnvelope>
 
   /// Fetch a user.
-  func fetchUser(userId userId: Int) -> SignalProducer<User, ErrorEnvelope>
+  func fetchUser(userId: Int) -> SignalProducer<User, ErrorEnvelope>
 
   /// Fetch the logged-in user's data.
   func fetchUserSelf() -> SignalProducer<User, ErrorEnvelope>
@@ -194,81 +194,81 @@ public protocol ServiceType {
   func incrementVideoStart(forProject project: Project) -> SignalProducer<VoidEnvelope, ErrorEnvelope>
 
   /// Attempt a login with an email, password and optional code.
-  func login(email email: String, password: String, code: String?) ->
+  func login(email: String, password: String, code: String?) ->
     SignalProducer<AccessTokenEnvelope, ErrorEnvelope>
 
   /// Attempt a login with Facebook access token and optional code.
-  func login(facebookAccessToken facebookAccessToken: String, code: String?) ->
+  func login(facebookAccessToken: String, code: String?) ->
     SignalProducer<AccessTokenEnvelope, ErrorEnvelope>
 
   /// Marks all the messages in a particular thread as read.
-  func markAsRead(messageThread messageThread: MessageThread) -> SignalProducer<MessageThread, ErrorEnvelope>
+  func markAsRead(messageThread: MessageThread) -> SignalProducer<MessageThread, ErrorEnvelope>
 
   /// Posts a comment to a project.
-  func postComment(body: String, toProject project: Project) -> SignalProducer<Comment, ErrorEnvelope>
+  func postComment(_ body: String, toProject project: Project) -> SignalProducer<Comment, ErrorEnvelope>
 
   /// Posts a comment to an update.
-  func postComment(body: String, toUpdate update: Update) -> SignalProducer<Comment, ErrorEnvelope>
+  func postComment(_ body: String, toUpdate update: Update) -> SignalProducer<Comment, ErrorEnvelope>
 
   /// Returns a project update preview URL.
-  func previewUrl(forDraft draft: UpdateDraft) -> NSURL?
+  func previewUrl(forDraft draft: UpdateDraft) -> URL?
 
   /// Publishes a project update draft.
-  func publish(draft draft: UpdateDraft) -> SignalProducer<Update, ErrorEnvelope>
+  func publish(draft: UpdateDraft) -> SignalProducer<Update, ErrorEnvelope>
 
   /// Registers a push token.
-  func register(pushToken pushToken: String) -> SignalProducer<VoidEnvelope, ErrorEnvelope>
+  func register(pushToken: String) -> SignalProducer<VoidEnvelope, ErrorEnvelope>
 
   /// Reset user password with email address.
-  func resetPassword(email email: String) -> SignalProducer<User, ErrorEnvelope>
+  func resetPassword(email: String) -> SignalProducer<User, ErrorEnvelope>
 
   /// Searches all of the messages, (optionally) bucketed to a specific project.
-  func searchMessages(query query: String, project: Project?)
+  func searchMessages(query: String, project: Project?)
     -> SignalProducer<MessageThreadsEnvelope, ErrorEnvelope>
 
   /// Sends a message to a subject, i.e. creator project, message thread, backer of backing.
-  func sendMessage(body body: String, toSubject subject: MessageSubject)
+  func sendMessage(body: String, toSubject subject: MessageSubject)
     -> SignalProducer<Message, ErrorEnvelope>
 
   /// Signup with email.
-  func signup(name name: String, email: String, password: String, passwordConfirmation: String,
+  func signup(name: String, email: String, password: String, passwordConfirmation: String,
                    sendNewsletters: Bool) -> SignalProducer<AccessTokenEnvelope, ErrorEnvelope>
 
   /// Signup with Facebook access token and newsletter bool.
-  func signup(facebookAccessToken facebookAccessToken: String, sendNewsletters: Bool) ->
+  func signup(facebookAccessToken: String, sendNewsletters: Bool) ->
     SignalProducer<AccessTokenEnvelope, ErrorEnvelope>
 
   /// Star a project.
-  func star(project: Project) -> SignalProducer<StarEnvelope, ErrorEnvelope>
+  func star(_ project: Project) -> SignalProducer<StarEnvelope, ErrorEnvelope>
 
-  func submitApplePay(checkoutUrl checkoutUrl: String,
+  func submitApplePay(checkoutUrl: String,
                       stripeToken: String,
                       paymentInstrumentName: String,
                       paymentNetwork: String,
                       transactionIdentifier: String) -> SignalProducer<SubmitApplePayEnvelope, ErrorEnvelope>
 
   /// Toggle the starred state on a project.
-  func toggleStar(project: Project) -> SignalProducer<StarEnvelope, ErrorEnvelope>
+  func toggleStar(_ project: Project) -> SignalProducer<StarEnvelope, ErrorEnvelope>
 
   /// Unfollow a user with their id.
   func unfollowFriend(userId id: Int) -> SignalProducer<VoidEnvelope, ErrorEnvelope>
 
   /// Performs the first step of checkout by creating a pledge on the server.
-  func updatePledge(project project: Project,
+  func updatePledge(project: Project,
                             amount: Double,
                             reward: Reward?,
                             shippingLocation: Location?,
                             tappedReward: Bool) -> SignalProducer<UpdatePledgeEnvelope, ErrorEnvelope>
 
   /// Update the project notification setting.
-  func updateProjectNotification(notification: ProjectNotification) ->
+  func updateProjectNotification(_ notification: ProjectNotification) ->
     SignalProducer<ProjectNotification, ErrorEnvelope>
 
   /// Update the current user with settings attributes.
-  func updateUserSelf(user: User) -> SignalProducer<User, ErrorEnvelope>
+  func updateUserSelf(_ user: User) -> SignalProducer<User, ErrorEnvelope>
 
   /// Updates the draft of a project update.
-  func update(draft draft: UpdateDraft, title: String, body: String, isPublic: Bool)
+  func update(draft: UpdateDraft, title: String, body: String, isPublic: Bool)
     -> SignalProducer<UpdateDraft, ErrorEnvelope>
 }
 
@@ -281,7 +281,7 @@ extension ServiceType {
 
 public func == (lhs: ServiceType, rhs: ServiceType) -> Bool {
   return
-    lhs.dynamicType == rhs.dynamicType &&
+    type(of: lhs) == type(of: rhs) &&
       lhs.serverConfig == rhs.serverConfig &&
       lhs.oauthToken == rhs.oauthToken &&
       lhs.language == rhs.language &&
@@ -302,42 +302,42 @@ extension ServiceType {
 
    - returns: A new URL request that is properly configured for the server.
    */
-  public func preparedRequest(forRequest originalRequest: NSURLRequest, query: [String:AnyObject] = [:])
-    -> NSURLRequest {
+  public func preparedRequest(forRequest originalRequest: URLRequest, query: [String:AnyObject] = [:])
+    -> URLRequest {
 
-      guard let request = originalRequest.mutableCopy() as? NSMutableURLRequest else {
+      guard let request = (originalRequest as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
         return originalRequest
       }
-      guard let URL = request.URL else {
+      guard let URL = request.url else {
         return originalRequest
       }
 
       var headers = self.defaultHeaders
 
-      let method = request.HTTPMethod.uppercaseString
-      let components = NSURLComponents(URL: URL, resolvingAgainstBaseURL: false)!
+      let method = request.httpMethod.uppercased()
+      var components = URLComponents(url: URL, resolvingAgainstBaseURL: false)!
       var queryItems = components.queryItems ?? []
-      queryItems.appendContentsOf(self.defaultQueryParams.map(NSURLQueryItem.init(name:value:)))
+      queryItems.append(contentsOf: self.defaultQueryParams.map(URLQueryItem.init(name:value:)))
 
       if method == "POST" || method == "PUT" {
-        if request.HTTPBody == nil {
+        if request.httpBody == nil {
           headers["Content-Type"] = "application/json; charset=utf-8"
-          request.HTTPBody = try? NSJSONSerialization.dataWithJSONObject(query, options: [])
+          request.httpBody = try? JSONSerialization.data(withJSONObject: query, options: [])
         }
       } else {
-        queryItems.appendContentsOf(
-          query
+        queryItems.append(
+          contentsOf: query
             .flatMap(queryComponents)
-            .map(NSURLQueryItem.init(name:value:))
+            .map(URLQueryItem.init(name:value:))
         )
       }
-      components.queryItems = queryItems.sort { $0.name < $1.name }
-      request.URL = components.URL
+      components.queryItems = queryItems.sorted { $0.name < $1.name }
+      request.url = components.url
 
       let currentHeaders = request.allHTTPHeaderFields ?? [:]
       request.allHTTPHeaderFields = currentHeaders.withAllValuesFrom(headers)
 
-      return request
+      return request as URLRequest
   }
 
   /**
@@ -349,40 +349,40 @@ extension ServiceType {
 
    - returns: A new URL request that is properly configured for the server.
    */
-  public func preparedRequest(forURL URL: NSURL, method: Method = .GET, query: [String:AnyObject] = [:])
-    -> NSURLRequest {
+  public func preparedRequest(forURL URL: Foundation.URL, method: Method = .GET, query: [String:AnyObject] = [:])
+    -> URLRequest {
 
-      let request = NSMutableURLRequest(URL: URL)
-      request.HTTPMethod = method.rawValue
-      return self.preparedRequest(forRequest: request, query: query)
+      let request = NSMutableURLRequest(url: URL)
+      request.httpMethod = method.rawValue
+      return self.preparedRequest(forRequest: request as URLRequest, query: query)
   }
 
-  public func isPrepared(request request: NSURLRequest) -> Bool {
-    return request.valueForHTTPHeaderField("Authorization") == authorizationHeader
-      && request.valueForHTTPHeaderField("Kickstarter-iOS-App") != nil
+  public func isPrepared(request: URLRequest) -> Bool {
+    return request.value(forHTTPHeaderField: "Authorization") == authorizationHeader
+      && request.value(forHTTPHeaderField: "Kickstarter-iOS-App") != nil
   }
 
-  private var defaultHeaders: [String:String] {
+  fileprivate var defaultHeaders: [String:String] {
     var headers: [String:String] = [:]
     headers["Accept-Language"] = self.language
     headers["Authorization"] = self.authorizationHeader
     headers["Kickstarter-App-Id"] = self.appId
     headers["Kickstarter-iOS-App"] = self.buildVersion
 
-    let executable = NSBundle.mainBundle().infoDictionary?["CFBundleExecutable"]
-    let bundleIdentifier = NSBundle.mainBundle().infoDictionary?["CFBundleIdentifier"]
-    let app: AnyObject = (executable ?? bundleIdentifier) ?? "Kickstarter"
-    let bundleVersion: AnyObject = NSBundle.mainBundle().infoDictionary?["CFBundleVersion"] ?? "1"
-    let model = UIDevice.currentDevice().model
-    let systemVersion = UIDevice.currentDevice().systemVersion
-    let scale = UIScreen.mainScreen().scale
+    let executable = Bundle.main.infoDictionary?["CFBundleExecutable"]
+    let bundleIdentifier = Bundle.main.infoDictionary?["CFBundleIdentifier"]
+    let app: AnyObject = (executable as AnyObject?? ?? bundleIdentifier as AnyObject?) ?? "Kickstarter" as AnyObject
+    let bundleVersion: AnyObject = Bundle.main.infoDictionary?["CFBundleVersion"] as AnyObject? ?? "1" as AnyObject
+    let model = UIDevice.current.model
+    let systemVersion = UIDevice.current.systemVersion
+    let scale = UIScreen.main.scale
 
     headers["User-Agent"] = "\(app)/\(bundleVersion) (\(model); iOS \(systemVersion) Scale/\(scale))"
 
     return headers
   }
 
-  private var authorizationHeader: String? {
+  fileprivate var authorizationHeader: String? {
     if let token = self.oauthToken?.token {
       return "token \(token)"
     } else {
@@ -390,14 +390,14 @@ extension ServiceType {
     }
   }
 
-  private var defaultQueryParams: [String:String] {
+  fileprivate var defaultQueryParams: [String:String] {
     var query: [String:String] = [:]
     query["client_id"] = self.serverConfig.apiClientAuth.clientId
     query["oauth_token"] = self.oauthToken?.token
     return query
   }
 
-  private func queryComponents(key: String, _ value: AnyObject) -> [(String, String)] {
+  fileprivate func queryComponents(_ key: String, _ value: AnyObject) -> [(String, String)] {
     var components: [(String, String)] = []
 
     if let dictionary = value as? [String: AnyObject] {
@@ -409,7 +409,7 @@ extension ServiceType {
         components += queryComponents("\(key)[]", value)
       }
     } else {
-      components.append((key, String(value)))
+      components.append((key, String(describing: value)))
     }
 
     return components

--- a/KsApi/extensions/NSURLSession.swift
+++ b/KsApi/extensions/NSURLSession.swift
@@ -7,6 +7,7 @@ import ReactiveSwift
 import Result
 
 private func parseJSONData(_ data: Data) -> AnyObject? {
+  // swiftlint:disable:next force_try
   return try! JSONSerialization.jsonObject(with: data, options: []) as AnyObject?
 }
 
@@ -23,7 +24,6 @@ internal extension URLSession {
         ?? self._rac_data(with: request)
 
       return producer
-//        .start(on: QueueScheduler(queue: queue))
         .start(on: scheduler)
         .flatMapError { _ in SignalProducer(error: .couldNotParseErrorEnvelopeJSON) } // NSError
         .flatMap(.concat) { data, response -> SignalProducer<Data, ErrorEnvelope> in

--- a/KsApi/extensions/NSURLSession.swift
+++ b/KsApi/extensions/NSURLSession.swift
@@ -6,9 +6,8 @@ import Prelude
 import ReactiveSwift
 import Result
 
-private func parseJSONData(_ data: Data) -> AnyObject? {
-  // FIXME: can anyobject be any here?
-  return (try? JSONSerialization.jsonObject(with: data, options: [])) as AnyObject?
+private func parseJSONData(_ data: Data) -> Any? {
+  return (try? JSONSerialization.jsonObject(with: data, options: []))
 }
 
 private let scheduler = QueueScheduler(qos: .background, name: "com.kickstarter.ksapi", targeting: nil)
@@ -59,11 +58,11 @@ internal extension URLSession {
   // Converts an URLSessionTask into a signal producer of raw JSON data. If the JSON does not parse
   // successfully, an `ErrorEnvelope.errorJSONCouldNotParse()` error is emitted.
   internal func rac_JSONResponse(_ request: URLRequest, uploading file: (url: URL, name: String)? = nil)
-    -> SignalProducer<AnyObject, ErrorEnvelope> {
+    -> SignalProducer<Any, ErrorEnvelope> {
 
       return self.rac_dataResponse(request, uploading: file)
         .map(parseJSONData)
-        .flatMap { json -> SignalProducer<AnyObject, ErrorEnvelope> in
+        .flatMap { json -> SignalProducer<Any, ErrorEnvelope> in
           guard let json = json else {
             return .init(error: .couldNotParseJSON)
           }

--- a/KsApi/extensions/NSURLSession.swift
+++ b/KsApi/extensions/NSURLSession.swift
@@ -7,6 +7,7 @@ import ReactiveSwift
 import Result
 
 private func parseJSONData(_ data: Data) -> AnyObject? {
+  // FIXME: can anyobject be any here?
   return (try? JSONSerialization.jsonObject(with: data, options: [])) as AnyObject?
 }
 

--- a/KsApi/extensions/NSURLSession.swift
+++ b/KsApi/extensions/NSURLSession.swift
@@ -143,13 +143,6 @@ extension URLSession {
       }
   }
 
-
-
-
-
-
-
-
   public func _rac_data(with request: URLRequest) -> SignalProducer<(Data, URLResponse), AnyError> {
     return SignalProducer { observer, disposable in
       let task = self.dataTask(with: request) { data, response, error in

--- a/KsApi/lib/Decodable.swift
+++ b/KsApi/lib/Decodable.swift
@@ -8,7 +8,7 @@ public extension Decodable {
 
    - returns: A decoded value.
    */
-  public static func decodeJSONDictionary(_ json: [String: Any]) -> Decoded<DecodedType> {
+  public static func decodeJSONDictionary(_ json: [String:Any]) -> Decoded<DecodedType> {
     return Self.decode(JSON(json))
   }
 }

--- a/KsApi/lib/Decodable.swift
+++ b/KsApi/lib/Decodable.swift
@@ -8,7 +8,7 @@ public extension Decodable {
 
    - returns: A decoded value.
    */
-  public static func decodeJSONDictionary(json: [String: AnyObject]) -> Decoded<DecodedType> {
+  public static func decodeJSONDictionary(_ json: [String: AnyObject]) -> Decoded<DecodedType> {
     return Self.decode(JSON(json))
   }
 }

--- a/KsApi/lib/Decodable.swift
+++ b/KsApi/lib/Decodable.swift
@@ -8,7 +8,7 @@ public extension Decodable {
 
    - returns: A decoded value.
    */
-  public static func decodeJSONDictionary(_ json: [String: AnyObject]) -> Decoded<DecodedType> {
+  public static func decodeJSONDictionary(_ json: [String: Any]) -> Decoded<DecodedType> {
     return Self.decode(JSON(json))
   }
 }

--- a/KsApi/lib/EncodableType.swift
+++ b/KsApi/lib/EncodableType.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 /**
- A type that can encode itself into a `[String:AnyObject]` dictionary, usually for then
+ A type that can encode itself into a `[String:Any]` dictionary, usually for then
  serializing to a JSON string.
 */
 public protocol EncodableType {
-  func encode() -> [String: AnyObject]
+  func encode() -> [String:Any]
 }
 
 public extension EncodableType {

--- a/KsApi/lib/EncodableType.swift
+++ b/KsApi/lib/EncodableType.swift
@@ -24,6 +24,6 @@ public extension EncodableType {
    - returns: `String`
    */
   public func toJSONString() -> String? {
-    return self.toJSONData().flatMap { String(data: $0, encoding: String.Encoding.utf8) }
+    return self.toJSONData().flatMap { String(data: $0, encoding: .utf8) }
   }
 }

--- a/KsApi/lib/EncodableType.swift
+++ b/KsApi/lib/EncodableType.swift
@@ -14,8 +14,8 @@ public extension EncodableType {
 
    - returns: `NSData`
    */
-  public func toJSONData() -> NSData? {
-    return try? NSJSONSerialization.dataWithJSONObject(encode(), options: [])
+  public func toJSONData() -> Data? {
+    return try? JSONSerialization.data(withJSONObject: encode(), options: [])
   }
 
   /**
@@ -24,6 +24,6 @@ public extension EncodableType {
    - returns: `String`
    */
   public func toJSONString() -> String? {
-    return self.toJSONData().flatMap { String(data: $0, encoding: NSUTF8StringEncoding) }
+    return self.toJSONData().flatMap { String(data: $0, encoding: String.Encoding.utf8) }
   }
 }

--- a/KsApi/lib/MimeType.swift
+++ b/KsApi/lib/MimeType.swift
@@ -20,7 +20,7 @@ extension Data {
 
 extension URL {
   internal var imageMime: String? {
-    return pathExtension.flatMap { mimeType(extension: $0, where: kUTTypeImage) }
+    return mimeType(extension: pathExtension, where: kUTTypeImage)
   }
 }
 

--- a/KsApi/lib/MimeType.swift
+++ b/KsApi/lib/MimeType.swift
@@ -3,8 +3,11 @@ import MobileCoreServices
 
 extension Data {
   internal var imageMime: String? {
-    guard let byte: UInt8 = UnsafeBufferPointer(start: (self as NSData).bytes.bindMemory(to: UInt8.self, capacity: self.count), count: 1).first
-      else { return nil }
+
+    let start = (self as NSData).bytes.bindMemory(to: UInt8.self, capacity: self.count)
+
+    guard let byte: UInt8 = UnsafeBufferPointer(start: start, count: 1).first else { return nil }
+    
     switch byte {
     case 0xFF:
       return mimeType(uti: kUTTypeJPEG)
@@ -25,8 +28,9 @@ extension URL {
 }
 
 private func mimeType(extension: String, where: CFString? = nil) -> String? {
-  let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, `extension` as CFString, `where`)?
-    .takeRetainedValue()
+  let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension,
+                                                  `extension` as CFString,
+                                                  `where`)?.takeRetainedValue()
   return uti.flatMap(mimeType(uti:))
 }
 

--- a/KsApi/lib/MimeType.swift
+++ b/KsApi/lib/MimeType.swift
@@ -23,7 +23,7 @@ extension Data {
 
 extension URL {
   internal var imageMime: String? {
-    return mimeType(extension: pathExtension, where: kUTTypeImage)
+    return mimeType(extension: self.pathExtension, where: kUTTypeImage)
   }
 }
 

--- a/KsApi/lib/MimeType.swift
+++ b/KsApi/lib/MimeType.swift
@@ -1,9 +1,9 @@
 import Foundation
 import MobileCoreServices
 
-extension NSData {
+extension Data {
   internal var imageMime: String? {
-    guard let byte: UInt8 = UnsafeBufferPointer(start: UnsafePointer(self.bytes), count: 1).first
+    guard let byte: UInt8 = UnsafeBufferPointer(start: (self as NSData).bytes.bindMemory(to: UInt8.self, capacity: self.count), count: 1).first
       else { return nil }
     switch byte {
     case 0xFF:
@@ -18,18 +18,18 @@ extension NSData {
   }
 }
 
-extension NSURL {
+extension URL {
   internal var imageMime: String? {
     return pathExtension.flatMap { mimeType(extension: $0, where: kUTTypeImage) }
   }
 }
 
-private func mimeType(extension extension: String, where: CFString? = nil) -> String? {
-  let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, `extension`, `where`)?
+private func mimeType(extension: String, where: CFString? = nil) -> String? {
+  let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, `extension` as CFString, `where`)?
     .takeRetainedValue()
   return uti.flatMap(mimeType(uti:))
 }
 
-private func mimeType(uti uti: CFString) -> String? {
+private func mimeType(uti: CFString) -> String? {
   return UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType)?.takeRetainedValue() as String?
 }

--- a/KsApi/lib/MimeType.swift
+++ b/KsApi/lib/MimeType.swift
@@ -7,7 +7,7 @@ extension Data {
     let start = (self as NSData).bytes.bindMemory(to: UInt8.self, capacity: self.count)
 
     guard let byte: UInt8 = UnsafeBufferPointer(start: start, count: 1).first else { return nil }
-    
+
     switch byte {
     case 0xFF:
       return mimeType(uti: kUTTypeJPEG)

--- a/KsApi/lib/Route.swift
+++ b/KsApi/lib/Route.swift
@@ -214,7 +214,7 @@ internal enum Route {
       return (.GET, "/v1/users/self/notifications", [:], nil)
 
     case let .projects(member):
-      return (.GET, "/v1/users/self/projects", ["member": member], nil)
+      return (.GET, "/v1/users/self/projects", ["member": member ? "1" : "0"], nil)
 
     case let .projectStats(projectId):
       return (.GET, "/v1/projects/\(projectId)/stats", [:], nil)

--- a/KsApi/lib/Route.swift
+++ b/KsApi/lib/Route.swift
@@ -73,12 +73,12 @@ internal enum Route {
   }
 
   internal var requestProperties:
-    (method: Method, path: String, query: [String:AnyObject], file: (name: UploadParam, url: URL)?) {
+    (method: Method, path: String, query: [String:Any], file: (name: UploadParam, url: URL)?) {
 
     switch self {
     case let .activities(categories, count):
-      var params: [String:AnyObject] = ["categories": categories.map { $0.rawValue }]
-      params["count"] = count as AnyObject?
+      var params: [String:AnyObject] = ["categories": categories.map { $0.rawValue } as AnyObject]
+      params["count"] = count as AnyObject
       return (.GET, "/v1/activities", params, nil)
 
     case let .addImage(file, draft):
@@ -98,10 +98,10 @@ internal enum Route {
 
     case let .changePaymentMethod(project):
       let changeMethodUrl = URL(string: project.urls.web.project)?
-        .URLByAppendingPathComponent("pledge")
-        .URLByAppendingPathComponent("change_method")
+        .appendingPathComponent("pledge")
+        .appendingPathComponent("change_method")
 
-      return (.PUT, changeMethodUrl?.absoluteString ?? "", ["format": "json"], nil)
+      return (.PUT, changeMethodUrl?.absoluteString ?? "", ["format": "json" as AnyObject], nil)
 
     case let .checkout(url):
       return (.GET, url, [:], nil)
@@ -114,7 +114,7 @@ internal enum Route {
         .appendingPathComponent("pledge")
 
       var params: [String:AnyObject] = [:]
-      params["clicked_reward"] = tappedReward ? "true" : nil
+      params["clicked_reward"] = (tappedReward ? "true" : nil) as AnyObject
       params["format"] = "json" as AnyObject?
       params["backing"] = [
         "amount": String(amount),
@@ -299,7 +299,7 @@ internal enum Route {
         .appendingPathComponent("pledge")
 
       var params: [String:AnyObject] = [:]
-      params["clicked_reward"] = tappedReward ? "true" : nil
+      params["clicked_reward"] = (tappedReward ? "true" : nil) as AnyObject
       params["format"] = "json" as AnyObject?
       params["backing"] = [
         "amount": String(amount),

--- a/KsApi/lib/Route.swift
+++ b/KsApi/lib/Route.swift
@@ -77,8 +77,8 @@ internal enum Route {
 
     switch self {
     case let .activities(categories, count):
-      var params: [String:AnyObject] = ["categories": categories.map { $0.rawValue } as AnyObject]
-      params["count"] = count as AnyObject
+      var params: [String:Any] = ["categories": categories.map { $0.rawValue }]
+      params["count"] = count
       return (.GET, "/v1/activities", params, nil)
 
     case let .addImage(file, draft):
@@ -101,7 +101,7 @@ internal enum Route {
         .appendingPathComponent("pledge")
         .appendingPathComponent("change_method")
 
-      return (.PUT, changeMethodUrl?.absoluteString ?? "", ["format": "json" as AnyObject], nil)
+      return (.PUT, changeMethodUrl?.absoluteString ?? "", ["format": "json"], nil)
 
     case let .checkout(url):
       return (.GET, url, [:], nil)
@@ -113,14 +113,14 @@ internal enum Route {
       let pledgeUrl = URL(string: project.urls.web.project)?
         .appendingPathComponent("pledge")
 
-      var params: [String:AnyObject] = [:]
-      params["clicked_reward"] = (tappedReward ? "true" : nil) as AnyObject
-      params["format"] = "json" as AnyObject?
+      var params: [String:Any] = [:]
+      params["clicked_reward"] = tappedReward ? "true" : nil
+      params["format"] = "json"
       params["backing"] = [
         "amount": String(amount),
         "backer_reward_id": reward.map { String($0.id) } ?? "",
         "location_id": shippingLocation.map { String($0.id) }
-        ].compact() as AnyObject?
+        ].compact()
 
       return (.POST, pledgeUrl?.absoluteString ?? "", params, nil)
 
@@ -131,21 +131,23 @@ internal enum Route {
       return (.DELETE, "/v1/projects/\(draft.update.projectId)/updates/draft/video/\(v.id)", [:], nil)
 
     case let .discover(params):
-      return (.GET, "/v1/discover", params.queryParams as [String : AnyObject], nil)
+      return (.GET, "/v1/discover", params.queryParams, nil)
 
     case let .facebookConnect(token):
-      return (.PUT, "v1/facebook/connect", ["access_token": token as AnyObject], nil)
+      return (.PUT, "v1/facebook/connect", ["access_token": token], nil)
 
     case let .facebookLogin(facebookAccessToken, code):
       var params = ["access_token": facebookAccessToken, "intent": "login"]
       params["code"] = code
-      return (.PUT, "/v1/facebook/access_token", params as [String : AnyObject], nil)
+      return (.PUT, "/v1/facebook/access_token", params, nil)
 
     case let .facebookSignup(facebookAccessToken, sendNewsletters):
-      let params: [String:AnyObject] = ["access_token": facebookAccessToken as AnyObject,
-                                        "intent": "register" as AnyObject,
-                                        "send_newsletters": sendNewsletters as AnyObject,
-                                        "newsletter_opt_in": sendNewsletters as AnyObject]
+      let params: [String:Any] = [
+        "access_token": facebookAccessToken,
+        "intent": "register",
+        "send_newsletters": sendNewsletters,
+        "newsletter_opt_in": sendNewsletters
+      ]
       return (.PUT, "/v1/facebook/access_token", params, nil)
 
     case let .fetchUpdateDraft(project):
@@ -155,28 +157,28 @@ internal enum Route {
       return (.GET, "v1/users/self/friends/find", [:], nil)
 
     case .friendStats:
-      return (.GET, "v1/users/self/friends/find", ["count": 0 as AnyObject], nil)
+      return (.GET, "v1/users/self/friends/find", ["count": 0], nil)
 
     case .followAllFriends:
       return (.PUT, "v1/users/self/friends/follow_all", [:], nil)
 
     case let .followFriend(userId):
-      return (.POST, "v1/users/self/friends", ["followed_id": userId as AnyObject], nil)
+      return (.POST, "v1/users/self/friends", ["followed_id": userId], nil)
 
     case let .incrementVideoCompletion(project):
       let statsURL = URL(string: project.urls.web.project)?
         .appendingPathComponent("video/plays")
-      return (.POST, statsURL?.absoluteString ?? "", ["event_type": "complete" as AnyObject, "location": "internal" as AnyObject], nil)
+      return (.POST, statsURL?.absoluteString ?? "", ["event_type": "complete", "location": "internal"], nil)
 
     case let .incrementVideoStart(project):
       let statsURL = URL(string: project.urls.web.project)?
         .appendingPathComponent("video/plays")
-      return (.POST, statsURL?.absoluteString ?? "", ["event_type": "start" as AnyObject, "location": "internal" as AnyObject], nil)
+      return (.POST, statsURL?.absoluteString ?? "", ["event_type": "start", "location": "internal"], nil)
 
     case let .login(email, password, code):
       var params = ["email": email, "password": password]
       params["code"] = code
-      return (.POST, "/xauth/access_token", params as [String : AnyObject], nil)
+      return (.POST, "/xauth/access_token", params, nil)
 
     case let .markAsRead(messageThread):
       return (.PUT, "/v1/message_threads/\(messageThread.id)/read", [:], nil)
@@ -194,10 +196,10 @@ internal enum Route {
       return (.GET, "/v1/message_threads/\(mailbox.rawValue)", [:], nil)
 
     case let .postProjectComment(p, body):
-      return (.POST, "/v1/projects/\(p.id)/comments", ["body": body as AnyObject], nil)
+      return (.POST, "/v1/projects/\(p.id)/comments", ["body": body], nil)
 
     case let .postUpdateComment(u, body):
-      return (.POST, "/v1/projects/\(u.projectId)/updates/\(u.id)/comments", ["body": body as AnyObject], nil)
+      return (.POST, "/v1/projects/\(u.projectId)/updates/\(u.id)/comments", ["body": body], nil)
 
     case let .project(param):
       return (.GET, "/v1/projects/\(param.escapedUrlComponent)", [:], nil)
@@ -212,7 +214,7 @@ internal enum Route {
       return (.GET, "/v1/users/self/notifications", [:], nil)
 
     case let .projects(member):
-      return (.GET, "/v1/users/self/projects", ["member": member as AnyObject], nil)
+      return (.GET, "/v1/users/self/projects", ["member": member], nil)
 
     case let .projectStats(projectId):
       return (.GET, "/v1/projects/\(projectId)/stats", [:], nil)
@@ -221,42 +223,44 @@ internal enum Route {
       return (.POST, "/v1/projects/\(d.update.projectId)/updates/draft/publish", [:], nil)
 
     case let .registerPushToken(token):
-      return (.POST, "v1/users/self/ios/push_tokens", ["token": token as AnyObject], nil)
+      return (.POST, "v1/users/self/ios/push_tokens", ["token": token], nil)
 
     case let .resetPassword(email):
-      return (.POST, "/v1/users/reset", ["email": email as AnyObject], nil)
+      return (.POST, "/v1/users/reset", ["email": email], nil)
 
     case let .searchMessages(query, project):
       if let project = project {
-        return (.GET, "/v1/projects/\(project.id)/message_threads/search", ["q": query as AnyObject], nil)
+        return (.GET, "/v1/projects/\(project.id)/message_threads/search", ["q": query], nil)
       }
-      return (.GET, "/v1/message_threads/search", ["q": query as AnyObject], nil)
+      return (.GET, "/v1/message_threads/search", ["q": query], nil)
 
     case let .sendMessage(body, messageSubject):
       switch messageSubject {
       case let .backing(backing):
         return (.POST,
                 "v1/projects/\(backing.projectId)/backers/\(backing.backerId)/messages",
-                ["body": body as AnyObject],
+                ["body": body],
                 nil)
 
       case let .messageThread(messageThread):
-        return (.POST, "/v1/message_threads/\(messageThread.id)/messages", ["body": body as AnyObject], nil)
+        return (.POST, "/v1/message_threads/\(messageThread.id)/messages", ["body": body], nil)
 
       case let .project(project):
-        return (.POST, "v1/projects/\(project.id)/messages", ["body": body as AnyObject], nil)
+        return (.POST, "v1/projects/\(project.id)/messages", ["body": body], nil)
       }
 
     case let .shippingRules(projectId, rewardId):
       return (.GET, "/v1/projects/\(projectId)/rewards/\(rewardId)/shipping_rules", [:], nil)
 
     case let .signup(name, email, password, passwordConfirmation, sendNewsletters):
-      let params: [String:AnyObject] = ["name": name as AnyObject,
-                                        "email": email as AnyObject,
-                                        "newsletter_opt_in": sendNewsletters as AnyObject,
-                                        "password": password as AnyObject,
-                                        "password_confirmation": passwordConfirmation as AnyObject,
-                                        "send_newsletters": sendNewsletters as AnyObject]
+      let params: [String:Any] = [
+        "name": name,
+        "email": email,
+        "newsletter_opt_in": sendNewsletters,
+        "password": password,
+        "password_confirmation": passwordConfirmation,
+        "send_newsletters": sendNewsletters
+      ]
       return (.POST, "/v1/users", params, nil)
 
     case let .star(p):
@@ -274,7 +278,7 @@ internal enum Route {
         "transaction_identifier": transactionIdentifier,
         ]
 
-      return (.POST, checkoutUrl, params as [String : AnyObject], nil)
+      return (.POST, checkoutUrl, params, nil)
 
     case let.surveyResponse(surveyResponseId):
       return (.GET, "/v1/users/self/surveys/\(surveyResponseId)", [:], nil)
@@ -298,24 +302,24 @@ internal enum Route {
       let pledgeUrl = URL(string: project.urls.web.project)?
         .appendingPathComponent("pledge")
 
-      var params: [String:AnyObject] = [:]
-      params["clicked_reward"] = (tappedReward ? "true" : nil) as AnyObject
-      params["format"] = "json" as AnyObject?
+      var params: [String:Any] = [:]
+      params["clicked_reward"] = tappedReward ? "true" : nil
+      params["format"] = "json"
       params["backing"] = [
         "amount": String(amount),
         "backer_reward_id": reward.map { String($0.id) } ?? "",
         "location_id": shippingLocation.map { String($0.id) }
-        ].compact() as AnyObject?
+        ].compact()
 
       return (.PUT, pledgeUrl?.absoluteString ?? "", params, nil)
 
     case let .updateUpdateDraft(d, title, body, isPublic):
-      let params: [String:AnyObject] = ["title": title as AnyObject, "body": body as AnyObject, "public": isPublic as AnyObject]
+      let params: [String:Any] = ["title": title, "body": body, "public": isPublic]
       return (.PUT, "/v1/projects/\(d.update.projectId)/updates/draft", params, nil)
 
     case let .updateProjectNotification(notification):
       let params = ["email": notification.email, "mobile": notification.mobile]
-      return (.PUT, "/v1/users/self/notifications/\(notification.id)", params as [String : AnyObject], nil)
+      return (.PUT, "/v1/users/self/notifications/\(notification.id)", params, nil)
 
     case let .updateUserSelf(user):
       let params = user.notifications.encode().withAllValuesFrom(user.newsletters.encode())

--- a/KsApi/lib/auth/BasicHTTPAuth.swift
+++ b/KsApi/lib/auth/BasicHTTPAuth.swift
@@ -24,7 +24,7 @@ extension BasicHTTPAuthType {
   */
   var authorizationHeader: String? {
     let string = "\(username):\(password)"
-    if let data = string.data(using: String.Encoding.utf8) {
+    if let data = string.data(using: .utf8) {
       let base64 = data.base64EncodedString(options: .lineLength64Characters)
       return "Basic \(base64)"
     }

--- a/KsApi/lib/auth/BasicHTTPAuth.swift
+++ b/KsApi/lib/auth/BasicHTTPAuth.swift
@@ -7,13 +7,13 @@ public protocol BasicHTTPAuthType {
 }
 
 public func == (lhs: BasicHTTPAuthType, rhs: BasicHTTPAuthType) -> Bool {
-  return lhs.dynamicType == rhs.dynamicType &&
+  return type(of: lhs) == type(of: rhs) &&
     lhs.username == rhs.username &&
     lhs.password == rhs.password
 }
 
 public func == (lhs: BasicHTTPAuthType?, rhs: BasicHTTPAuthType?) -> Bool {
-  return lhs?.dynamicType == rhs?.dynamicType &&
+  return type(of: lhs) == type(of: rhs) &&
     lhs?.username == rhs?.username &&
     lhs?.password == rhs?.password
 }
@@ -24,8 +24,8 @@ extension BasicHTTPAuthType {
   */
   var authorizationHeader: String? {
     let string = "\(username):\(password)"
-    if let data = string.dataUsingEncoding(NSUTF8StringEncoding) {
-      let base64 = data.base64EncodedStringWithOptions(.Encoding64CharacterLineLength)
+    if let data = string.data(using: String.Encoding.utf8) {
+      let base64 = data.base64EncodedString(options: .lineLength64Characters)
       return "Basic \(base64)"
     }
     return nil

--- a/KsApi/lib/auth/ClientAuth.swift
+++ b/KsApi/lib/auth/ClientAuth.swift
@@ -6,7 +6,7 @@ public protocol ClientAuthType {
 }
 
 public func == (lhs: ClientAuthType, rhs: ClientAuthType) -> Bool {
-  return lhs.dynamicType == rhs.dynamicType &&
+  return type(of: lhs) == type(of: rhs) &&
     lhs.clientId == rhs.clientId
 }
 

--- a/KsApi/lib/auth/OauthToken.swift
+++ b/KsApi/lib/auth/OauthToken.swift
@@ -6,12 +6,12 @@ public protocol OauthTokenAuthType {
 }
 
 public func == (lhs: OauthTokenAuthType, rhs: OauthTokenAuthType) -> Bool {
-  return lhs.dynamicType == rhs.dynamicType &&
+  return type(of: lhs) == type(of: rhs) &&
     lhs.token == rhs.token
 }
 
 public func == (lhs: OauthTokenAuthType?, rhs: OauthTokenAuthType?) -> Bool {
-  return lhs?.dynamicType == rhs?.dynamicType &&
+  return type(of: lhs) == type(of: rhs) &&
     lhs?.token == rhs?.token
 }
 

--- a/KsApi/models/AccessTokenEnvelope.swift
+++ b/KsApi/models/AccessTokenEnvelope.swift
@@ -7,7 +7,7 @@ public struct AccessTokenEnvelope {
 }
 
 extension AccessTokenEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<AccessTokenEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<AccessTokenEnvelope> {
     return curry(AccessTokenEnvelope.init)
       <^> json <| "access_token"
       <*> json <| "user"

--- a/KsApi/models/AccessTokenEnvelope.swift
+++ b/KsApi/models/AccessTokenEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct AccessTokenEnvelope {
   public let accessToken: String

--- a/KsApi/models/Activity.swift
+++ b/KsApi/models/Activity.swift
@@ -5,7 +5,7 @@ import Curry
 public struct Activity {
   public let category: Activity.Category
   public let comment: Comment?
-  public let createdAt: NSTimeInterval
+  public let createdAt: TimeInterval
   public let id: Int
   public let memberData: MemberData
   public let project: Project?
@@ -50,7 +50,7 @@ public func == (lhs: Activity, rhs: Activity) -> Bool {
 }
 
 extension Activity: Decodable {
-  public static func decode(json: JSON) -> Decoded<Activity> {
+  public static func decode(_ json: JSON) -> Decoded<Activity> {
     let create = curry(Activity.init)
     let tmp = create
       <^> json <|  "category"
@@ -66,7 +66,7 @@ extension Activity: Decodable {
 }
 
 extension Activity.Category: Decodable {
-  public static func decode(json: JSON) -> Decoded<Activity.Category> {
+  public static func decode(_ json: JSON) -> Decoded<Activity.Category> {
     switch json {
     case let .String(category):
       return .Success(Activity.Category(rawValue: category) ?? .unknown)
@@ -77,7 +77,7 @@ extension Activity.Category: Decodable {
 }
 
 extension Activity.MemberData: Decodable {
-  public static func decode(json: JSON) -> Decoded<Activity.MemberData> {
+  public static func decode(_ json: JSON) -> Decoded<Activity.MemberData> {
     let create = curry(Activity.MemberData.init)
     let tmp = create
       <^> json <|? "amount"

--- a/KsApi/models/Activity.swift
+++ b/KsApi/models/Activity.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Argo
 import Curry
+import Runes
 
 public struct Activity {
   public let category: Activity.Category
@@ -68,10 +69,10 @@ extension Activity: Decodable {
 extension Activity.Category: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Activity.Category> {
     switch json {
-    case let .String(category):
-      return .Success(Activity.Category(rawValue: category) ?? .unknown)
+    case let .string(category):
+      return .success(Activity.Category(rawValue: category) ?? .unknown)
     default:
-      return .Failure(.TypeMismatch(expected: "String", actual: json.description))
+      return .failure(.typeMismatch(expected: "String", actual: json.description))
     }
   }
 }

--- a/KsApi/models/ActivityEnvelope.swift
+++ b/KsApi/models/ActivityEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct ActivityEnvelope {
   public let activities: [Activity]
@@ -32,6 +33,6 @@ extension ActivityEnvelope.UrlsEnvelope: Decodable {
 extension ActivityEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ActivityEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(ActivityEnvelope.UrlsEnvelope.ApiEnvelope.init)
-      <^> json <| "more_activities" <|> .Success("")
+      <^> (json <| "more_activities" <|> .success(""))
   }
 }

--- a/KsApi/models/ActivityEnvelope.swift
+++ b/KsApi/models/ActivityEnvelope.swift
@@ -15,7 +15,7 @@ public struct ActivityEnvelope {
 }
 
 extension ActivityEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<ActivityEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<ActivityEnvelope> {
     return curry(ActivityEnvelope.init)
       <^> json <|| "activities"
       <*> json <|  "urls"
@@ -23,14 +23,14 @@ extension ActivityEnvelope: Decodable {
 }
 
 extension ActivityEnvelope.UrlsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<ActivityEnvelope.UrlsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<ActivityEnvelope.UrlsEnvelope> {
     return curry(ActivityEnvelope.UrlsEnvelope.init)
       <^> json <| "api"
   }
 }
 
 extension ActivityEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<ActivityEnvelope.UrlsEnvelope.ApiEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<ActivityEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(ActivityEnvelope.UrlsEnvelope.ApiEnvelope.init)
       <^> json <| "more_activities" <|> .Success("")
   }

--- a/KsApi/models/Backing.swift
+++ b/KsApi/models/Backing.swift
@@ -7,7 +7,7 @@ public struct Backing {
   public let backerId: Int
   public let id: Int
   public let locationId: Int?
-  public let pledgedAt: NSTimeInterval
+  public let pledgedAt: TimeInterval
   public let projectCountry: String
   public let projectId: Int
   public let reward: Reward?
@@ -33,7 +33,7 @@ public func == (lhs: Backing, rhs: Backing) -> Bool {
 }
 
 extension Backing: Decodable {
-  public static func decode(json: JSON) -> Decoded<Backing> {
+  public static func decode(_ json: JSON) -> Decoded<Backing> {
     let create = curry(Backing.init)
     let tmp = create
       <^> json <| "amount"

--- a/KsApi/models/Backing.swift
+++ b/KsApi/models/Backing.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct Backing {
   public let amount: Int

--- a/KsApi/models/CategoriesEnvelope.swift
+++ b/KsApi/models/CategoriesEnvelope.swift
@@ -6,7 +6,7 @@ public struct CategoriesEnvelope {
 }
 
 extension CategoriesEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<CategoriesEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<CategoriesEnvelope> {
     return curry(CategoriesEnvelope.init)
       <^> json <|| "categories"
   }

--- a/KsApi/models/CategoriesEnvelope.swift
+++ b/KsApi/models/CategoriesEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct CategoriesEnvelope {
   public let categories: [Category]

--- a/KsApi/models/Category.swift
+++ b/KsApi/models/Category.swift
@@ -1,18 +1,6 @@
 import Argo
 import Curry
 import Runes
-// FIXME: comparison operators with optionals were removed from the Swift Standard Libary.
-// Consider refactoring the code to use the non-optional operators.
-fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
-  switch (lhs, rhs) {
-  case let (l?, r?):
-    return l < r
-  case (nil, _?):
-    return true
-  default:
-    return false
-  }
-}
 
 public struct Category {
   public let color: Int?
@@ -96,7 +84,11 @@ public func < (lhs: Category, rhs: Category) -> Bool {
     return false
   }
 
-  return lhs.root?.name < rhs.root?.name
+  if let lhsRootName = lhs.root?.name, let rhsRootName = rhs.root?.name {
+    return lhsRootName < rhsRootName
+  }
+
+  return lhs.root == nil
 }
 
 extension Category: CustomStringConvertible, CustomDebugStringConvertible {

--- a/KsApi/models/Category.swift
+++ b/KsApi/models/Category.swift
@@ -1,5 +1,18 @@
 import Argo
 import Curry
+// FIXME: comparison operators with optionals were removed from the Swift Standard Libary.
+// Consider refactoring the code to use the non-optional operators.
+fileprivate func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+  switch (lhs, rhs) {
+  case let (l?, r?):
+    return l < r
+  case (nil, _?):
+    return true
+  default:
+    return false
+  }
+}
+
 
 public struct Category {
   public let color: Int?
@@ -98,7 +111,7 @@ extension Category: CustomStringConvertible, CustomDebugStringConvertible {
 
 extension Category: Decodable {
 
-  public static func decode(json: JSON) -> Decoded<Category> {
+  public static func decode(_ json: JSON) -> Decoded<Category> {
     let create = curry(Category.init)
     let tmp = create
       <^> json <|? "color"

--- a/KsApi/models/Category.swift
+++ b/KsApi/models/Category.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 // FIXME: comparison operators with optionals were removed from the Swift Standard Libary.
 // Consider refactoring the code to use the non-optional operators.
 fileprivate func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {

--- a/KsApi/models/Category.swift
+++ b/KsApi/models/Category.swift
@@ -3,7 +3,7 @@ import Curry
 import Runes
 // FIXME: comparison operators with optionals were removed from the Swift Standard Libary.
 // Consider refactoring the code to use the non-optional operators.
-fileprivate func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
     return l < r
@@ -13,7 +13,6 @@ fileprivate func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
     return false
   }
 }
-
 
 public struct Category {
   public let color: Int?

--- a/KsApi/models/ChangePaymentMethodEnvelope.swift
+++ b/KsApi/models/ChangePaymentMethodEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct ChangePaymentMethodEnvelope {
   public let newCheckoutUrl: String?
@@ -16,7 +17,7 @@ extension ChangePaymentMethodEnvelope: Decodable {
 
 private func stringToIntOrZero(_ string: String) -> Decoded<Int> {
   return
-    Double(string).flatMap(Int.init).map(Decoded.Success)
-      ?? Int(string).map(Decoded.Success)
-      ?? .Success(0)
+    Double(string).flatMap(Int.init).map(Decoded.success)
+      ?? Int(string).map(Decoded.success)
+      ?? .success(0)
 }

--- a/KsApi/models/ChangePaymentMethodEnvelope.swift
+++ b/KsApi/models/ChangePaymentMethodEnvelope.swift
@@ -7,14 +7,14 @@ public struct ChangePaymentMethodEnvelope {
 }
 
 extension ChangePaymentMethodEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<ChangePaymentMethodEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<ChangePaymentMethodEnvelope> {
     return curry(ChangePaymentMethodEnvelope.init)
       <^> json <|? ["data", "new_checkout_url"]
       <*> ((json <| "status" >>- stringToIntOrZero) <|> (json <| "status"))
   }
 }
 
-private func stringToIntOrZero(string: String) -> Decoded<Int> {
+private func stringToIntOrZero(_ string: String) -> Decoded<Int> {
   return
     Double(string).flatMap(Int.init).map(Decoded.Success)
       ?? Int(string).map(Decoded.Success)

--- a/KsApi/models/CheckoutEnvelope.swift
+++ b/KsApi/models/CheckoutEnvelope.swift
@@ -13,7 +13,7 @@ public struct CheckoutEnvelope {
 }
 
 extension CheckoutEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<CheckoutEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<CheckoutEnvelope> {
     let create = curry(CheckoutEnvelope.init)
     return create
       <^> json <| "state"

--- a/KsApi/models/CheckoutEnvelope.swift
+++ b/KsApi/models/CheckoutEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct CheckoutEnvelope {
   public enum State: String {
@@ -17,7 +18,7 @@ extension CheckoutEnvelope: Decodable {
     let create = curry(CheckoutEnvelope.init)
     return create
       <^> json <| "state"
-      <*> json <| "state_reason" <|> .Success("")
+      <*> (json <| "state_reason" <|> .success(""))
   }
 }
 

--- a/KsApi/models/Comment.swift
+++ b/KsApi/models/Comment.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct Comment {
   public let author: User
@@ -30,7 +31,7 @@ public func == (lhs: Comment, rhs: Comment) -> Bool {
 // sends back `0` when the comment hasn't been deleted, and we'd rather handle that value as `nil`.
 private func decodePositiveTimeInterval(_ interval: TimeInterval?) -> Decoded<TimeInterval?> {
   if let interval = interval, interval > 0.0 {
-    return .Success(interval)
+    return .success(interval)
   }
-  return .Success(nil)
+  return .success(nil)
 }

--- a/KsApi/models/Comment.swift
+++ b/KsApi/models/Comment.swift
@@ -4,13 +4,13 @@ import Curry
 public struct Comment {
   public let author: User
   public let body: String
-  public let createdAt: NSTimeInterval
-  public let deletedAt: NSTimeInterval?
+  public let createdAt: TimeInterval
+  public let deletedAt: TimeInterval?
   public let id: Int
 }
 
 extension Comment: Decodable {
-  public static func decode(json: JSON) -> Decoded<Comment> {
+  public static func decode(_ json: JSON) -> Decoded<Comment> {
     return curry(Comment.init)
       <^> json <| "author"
       <*> json <| "body"
@@ -28,8 +28,8 @@ public func == (lhs: Comment, rhs: Comment) -> Bool {
 
 // Decode a time interval so that non-positive values are coalesced to `nil`. We do this because the API
 // sends back `0` when the comment hasn't been deleted, and we'd rather handle that value as `nil`.
-private func decodePositiveTimeInterval(interval: NSTimeInterval?) -> Decoded<NSTimeInterval?> {
-  if let interval = interval where interval > 0.0 {
+private func decodePositiveTimeInterval(_ interval: TimeInterval?) -> Decoded<TimeInterval?> {
+  if let interval = interval, interval > 0.0 {
     return .Success(interval)
   }
   return .Success(nil)

--- a/KsApi/models/CommentsEnvelope.swift
+++ b/KsApi/models/CommentsEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct CommentsEnvelope {
   public let comments: [Comment]
@@ -32,6 +33,6 @@ extension CommentsEnvelope.UrlsEnvelope: Decodable {
 extension CommentsEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<CommentsEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(CommentsEnvelope.UrlsEnvelope.ApiEnvelope.init)
-      <^> json <| "more_comments" <|> .Success("")
+      <^> (json <| "more_comments" <|> .success(""))
   }
 }

--- a/KsApi/models/CommentsEnvelope.swift
+++ b/KsApi/models/CommentsEnvelope.swift
@@ -15,7 +15,7 @@ public struct CommentsEnvelope {
 }
 
 extension CommentsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<CommentsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<CommentsEnvelope> {
     return curry(CommentsEnvelope.init)
       <^> json <|| "comments"
       <*> json <| "urls"
@@ -23,14 +23,14 @@ extension CommentsEnvelope: Decodable {
 }
 
 extension CommentsEnvelope.UrlsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<CommentsEnvelope.UrlsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<CommentsEnvelope.UrlsEnvelope> {
     return curry(CommentsEnvelope.UrlsEnvelope.init)
       <^> json <| "api"
   }
 }
 
 extension CommentsEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<CommentsEnvelope.UrlsEnvelope.ApiEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<CommentsEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(CommentsEnvelope.UrlsEnvelope.ApiEnvelope.init)
       <^> json <| "more_comments" <|> .Success("")
   }

--- a/KsApi/models/Config.swift
+++ b/KsApi/models/Config.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct Config {
   public let abExperiments: [String:String]
@@ -45,16 +46,16 @@ public func == (lhs: Config, rhs: Config) -> Bool {
 }
 
 extension Config: EncodableType {
-  public func encode() -> [String : AnyObject] {
-    var result: [String:AnyObject] = [:]
-    result["ab_experiments"] = self.abExperiments as AnyObject?
-    result["app_id"] = self.appId as AnyObject?
-    result["apple_pay_countries"] = self.applePayCountries as AnyObject?
-    result["country_code"] = self.countryCode as AnyObject?
-    result["features"] = self.features as AnyObject?
-    result["itunes_link"] = self.iTunesLink as AnyObject?
+  public func encode() -> [String : Any] {
+    var result: [String:Any] = [:]
+    result["ab_experiments"] = self.abExperiments
+    result["app_id"] = self.appId
+    result["apple_pay_countries"] = self.applePayCountries
+    result["country_code"] = self.countryCode
+    result["features"] = self.features
+    result["itunes_link"] = self.iTunesLink
     result["launched_countries"] = self.launchedCountries.map { $0.encode() }
-    result["locale"] = self.locale as AnyObject?
+    result["locale"] = self.locale
     result["stripe"] = ["publishable_key": self.stripePublishableKey]
     return result
   }
@@ -66,7 +67,7 @@ extension Config: EncodableType {
 private func decodeDictionary<T: Decodable>(_ j: Decoded<JSON>)
   -> Decoded<[String:T]> where T.DecodedType == T {
   switch j {
-  case let .Success(json): return [String: T].decode(json)
-  case let .Failure(e): return .Failure(e)
+  case let .success(json): return [String: T].decode(json)
+  case let .failure(e): return .failure(e)
   }
 }

--- a/KsApi/models/Config.swift
+++ b/KsApi/models/Config.swift
@@ -14,7 +14,7 @@ public struct Config {
 }
 
 extension Config: Decodable {
-  public static func decode(json: JSON) -> Decoded<Config> {
+  public static func decode(_ json: JSON) -> Decoded<Config> {
     let create = curry(Config.init)
     let tmp = create
       <^> decodeDictionary(json <| "ab_experiments")
@@ -47,14 +47,14 @@ public func == (lhs: Config, rhs: Config) -> Bool {
 extension Config: EncodableType {
   public func encode() -> [String : AnyObject] {
     var result: [String:AnyObject] = [:]
-    result["ab_experiments"] = self.abExperiments
-    result["app_id"] = self.appId
-    result["apple_pay_countries"] = self.applePayCountries
-    result["country_code"] = self.countryCode
-    result["features"] = self.features
-    result["itunes_link"] = self.iTunesLink
+    result["ab_experiments"] = self.abExperiments as AnyObject?
+    result["app_id"] = self.appId as AnyObject?
+    result["apple_pay_countries"] = self.applePayCountries as AnyObject?
+    result["country_code"] = self.countryCode as AnyObject?
+    result["features"] = self.features as AnyObject?
+    result["itunes_link"] = self.iTunesLink as AnyObject?
     result["launched_countries"] = self.launchedCountries.map { $0.encode() }
-    result["locale"] = self.locale
+    result["locale"] = self.locale as AnyObject?
     result["stripe"] = ["publishable_key": self.stripePublishableKey]
     return result
   }
@@ -63,8 +63,8 @@ extension Config: EncodableType {
 // Useful for getting around swift optimization bug: https://github.com/thoughtbot/Argo/issues/363
 // Turns out using `>>-` or `flatMap` on a `Decoded` fails to compile with optimizations on, so this
 // function does it manually.
-private func decodeDictionary<T: Decodable where T.DecodedType == T>(j: Decoded<JSON>)
-  -> Decoded<[String:T]> {
+private func decodeDictionary<T: Decodable>(_ j: Decoded<JSON>)
+  -> Decoded<[String:T]> where T.DecodedType == T {
   switch j {
   case let .Success(json): return [String: T].decode(json)
   case let .Failure(e): return .Failure(e)

--- a/KsApi/models/Config.swift
+++ b/KsApi/models/Config.swift
@@ -46,7 +46,7 @@ public func == (lhs: Config, rhs: Config) -> Bool {
 }
 
 extension Config: EncodableType {
-  public func encode() -> [String : Any] {
+  public func encode() -> [String:Any] {
     var result: [String:Any] = [:]
     result["ab_experiments"] = self.abExperiments
     result["app_id"] = self.appId

--- a/KsApi/models/CreatePledgeEnvelope.swift
+++ b/KsApi/models/CreatePledgeEnvelope.swift
@@ -8,7 +8,7 @@ public struct CreatePledgeEnvelope {
 }
 
 extension CreatePledgeEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<CreatePledgeEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<CreatePledgeEnvelope> {
     return curry(CreatePledgeEnvelope.init)
       <^> json <|? ["data", "checkout_url"]
       <*> json <|? ["data", "new_checkout_url"]
@@ -16,7 +16,7 @@ extension CreatePledgeEnvelope: Decodable {
   }
 }
 
-private func stringToIntOrZero(string: String) -> Decoded<Int> {
+private func stringToIntOrZero(_ string: String) -> Decoded<Int> {
   return
     Double(string).flatMap(Int.init).map(Decoded.Success)
       ?? Int(string).map(Decoded.Success)

--- a/KsApi/models/CreatePledgeEnvelope.swift
+++ b/KsApi/models/CreatePledgeEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct CreatePledgeEnvelope {
   public let checkoutUrl: String?
@@ -18,7 +19,7 @@ extension CreatePledgeEnvelope: Decodable {
 
 private func stringToIntOrZero(_ string: String) -> Decoded<Int> {
   return
-    Double(string).flatMap(Int.init).map(Decoded.Success)
-      ?? Int(string).map(Decoded.Success)
-      ?? .Success(0)
+    Double(string).flatMap(Int.init).map(Decoded.success)
+      ?? Int(string).map(Decoded.success)
+      ?? .success(0)
 }

--- a/KsApi/models/DiscoveryEnvelope.swift
+++ b/KsApi/models/DiscoveryEnvelope.swift
@@ -24,7 +24,7 @@ public struct DiscoveryEnvelope {
 }
 
 extension DiscoveryEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<DiscoveryEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<DiscoveryEnvelope> {
     return curry(DiscoveryEnvelope.init)
       <^> json <|| "projects"
       <*> json <|  "urls"
@@ -33,21 +33,21 @@ extension DiscoveryEnvelope: Decodable {
 }
 
 extension DiscoveryEnvelope.UrlsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<DiscoveryEnvelope.UrlsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<DiscoveryEnvelope.UrlsEnvelope> {
     return curry(DiscoveryEnvelope.UrlsEnvelope.init)
       <^> json <| "api"
   }
 }
 
 extension DiscoveryEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<DiscoveryEnvelope.UrlsEnvelope.ApiEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<DiscoveryEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(DiscoveryEnvelope.UrlsEnvelope.ApiEnvelope.init)
       <^> json <| "more_projects"
   }
 }
 
 extension DiscoveryEnvelope.StatsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<DiscoveryEnvelope.StatsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<DiscoveryEnvelope.StatsEnvelope> {
     return curry(DiscoveryEnvelope.StatsEnvelope.init)
       <^> json <| "count"
   }

--- a/KsApi/models/DiscoveryEnvelope.swift
+++ b/KsApi/models/DiscoveryEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct DiscoveryEnvelope {
   public let projects: [Project]

--- a/KsApi/models/DiscoveryParams.swift
+++ b/KsApi/models/DiscoveryParams.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 import Prelude
 
 public struct DiscoveryParams {
@@ -117,27 +118,27 @@ extension DiscoveryParams: Decodable {
 }
 
 private func stringToBool(_ string: String?) -> Decoded<Bool?> {
-  guard let string = string else { return .Success(nil) }
+  guard let string = string else { return .success(nil) }
   switch string {
   // taken from server's `value_to_boolean` function
   case "true", "1", "t", "T", "true", "TRUE", "on", "ON":
-    return .Success(true)
+    return .success(true)
   case "false", "0", "f", "F", "false", "FALSE", "off", "OFF":
-    return .Success(false)
+    return .success(false)
   default:
-    return .Failure(.Custom("Could not parse string into bool."))
+    return .failure(.custom("Could not parse string into bool."))
   }
 }
 
 private func stringToInt(_ string: String?) -> Decoded<Int?> {
-  guard let string = string else { return .Success(nil) }
-  return Int(string).map(Decoded.Success) ?? .Failure(.Custom("Could not parse string into int."))
+  guard let string = string else { return .success(nil) }
+  return Int(string).map(Decoded.success) ?? .failure(.custom("Could not parse string into int."))
 }
 
 private func stringIntToBool(_ string: String?) -> Decoded<Bool?> {
-  guard let string = string else { return .Success(nil) }
+  guard let string = string else { return .success(nil) }
   return Int(string)
     .filter { $0 <= 1 && $0 >= -1 }
-    .map { .Success($0 == 0 ? nil : $0 == 1) }
-    ?? .Failure(.Custom("Could not parse string into bool."))
+    .map { .success($0 == 0 ? nil : $0 == 1) }
+    .coalesceWith(.failure(.custom("Could not parse string into bool.")))
 }

--- a/KsApi/models/DiscoveryParams.swift
+++ b/KsApi/models/DiscoveryParams.swift
@@ -91,7 +91,7 @@ extension DiscoveryParams: CustomStringConvertible, CustomDebugStringConvertible
 }
 
 extension DiscoveryParams: Decodable {
-  public static func decode(json: JSON) -> Decoded<DiscoveryParams> {
+  public static func decode(_ json: JSON) -> Decoded<DiscoveryParams> {
     let create = curry(DiscoveryParams.init)
     let tmp1 = create
       <^> (json <|? "backed" >>- stringIntToBool)
@@ -116,7 +116,7 @@ extension DiscoveryParams: Decodable {
   }
 }
 
-private func stringToBool(string: String?) -> Decoded<Bool?> {
+private func stringToBool(_ string: String?) -> Decoded<Bool?> {
   guard let string = string else { return .Success(nil) }
   switch string {
   // taken from server's `value_to_boolean` function
@@ -129,12 +129,12 @@ private func stringToBool(string: String?) -> Decoded<Bool?> {
   }
 }
 
-private func stringToInt(string: String?) -> Decoded<Int?> {
+private func stringToInt(_ string: String?) -> Decoded<Int?> {
   guard let string = string else { return .Success(nil) }
   return Int(string).map(Decoded.Success) ?? .Failure(.Custom("Could not parse string into int."))
 }
 
-private func stringIntToBool(string: String?) -> Decoded<Bool?> {
+private func stringIntToBool(_ string: String?) -> Decoded<Bool?> {
   guard let string = string else { return .Success(nil) }
   return Int(string)
     .filter { $0 <= 1 && $0 >= -1 }

--- a/KsApi/models/ErrorEnvelope.swift
+++ b/KsApi/models/ErrorEnvelope.swift
@@ -79,7 +79,7 @@ public struct ErrorEnvelope {
 
    - returns: An error envelope that describes why decoding failed.
    */
-  internal static func couldNotDecodeJSON(decodeError: DecodeError) -> ErrorEnvelope {
+  internal static func couldNotDecodeJSON(_ decodeError: DecodeError) -> ErrorEnvelope {
     return ErrorEnvelope(
       errorMessages: ["Argo decoding error: \(decodeError.description)"],
       ksrCode: .DecodingJSONFailed,
@@ -105,10 +105,10 @@ public struct ErrorEnvelope {
   )
 }
 
-extension ErrorEnvelope: ErrorType {}
+extension ErrorEnvelope: Error {}
 
 extension ErrorEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<ErrorEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<ErrorEnvelope> {
     let create = curry(ErrorEnvelope.init)
 
     // Typically API errors come back in this form...
@@ -137,7 +137,7 @@ extension ErrorEnvelope: Decodable {
 }
 
 extension ErrorEnvelope.Exception: Decodable {
-  public static func decode(json: JSON) -> Decoded<ErrorEnvelope.Exception> {
+  public static func decode(_ json: JSON) -> Decoded<ErrorEnvelope.Exception> {
     return curry(ErrorEnvelope.Exception.init)
       <^> json <||? "backtrace"
       <*> json <|? "message"
@@ -145,7 +145,7 @@ extension ErrorEnvelope.Exception: Decodable {
 }
 
 extension ErrorEnvelope.KsrCode: Decodable {
-  public static func decode(j: JSON) -> Decoded<ErrorEnvelope.KsrCode> {
+  public static func decode(_ j: JSON) -> Decoded<ErrorEnvelope.KsrCode> {
     switch j {
     case let .String(s):
       return pure(ErrorEnvelope.KsrCode(rawValue: s) ?? ErrorEnvelope.KsrCode.UnknownCode)
@@ -156,7 +156,7 @@ extension ErrorEnvelope.KsrCode: Decodable {
 }
 
 extension ErrorEnvelope.FacebookUser: Decodable {
-  public static func decode(json: JSON) -> Decoded<ErrorEnvelope.FacebookUser> {
+  public static func decode(_ json: JSON) -> Decoded<ErrorEnvelope.FacebookUser> {
     return curry(ErrorEnvelope.FacebookUser.init)
       <^> json <| "id"
       <*> json <| "name"
@@ -166,7 +166,7 @@ extension ErrorEnvelope.FacebookUser: Decodable {
 
 // Concats an array of decoded arrays into a decoded array. Ignores all failed decoded values, and so
 // always returns a successfully decoded value.
-private func concatSuccesses<A>(decodeds: [Decoded<[A]>]) -> Decoded<[A]> {
+private func concatSuccesses<A>(_ decodeds: [Decoded<[A]>]) -> Decoded<[A]> {
 
   return decodeds.reduce(Decoded.Success([])) { accum, decoded in
     .Success( (accum.value ?? []) + (decoded.value ?? []) )

--- a/KsApi/models/ErrorEnvelope.swift
+++ b/KsApi/models/ErrorEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct ErrorEnvelope {
   public let errorMessages: [String]
@@ -126,10 +127,10 @@ extension ErrorEnvelope: Decodable {
           json <|| ["data", "errors", "amount"],
           json <|| ["data", "errors", "backer_reward"],
           ])
-        <*> .Success(ErrorEnvelope.KsrCode.UnknownCode)
+        <*> .success(ErrorEnvelope.KsrCode.UnknownCode)
         <*> json <| "status"
-        <*> .Success(nil)
-        <*> .Success(nil)
+        <*> .success(nil)
+        <*> .success(nil)
     }
 
     return standardErrorEnvelope <|> nonStandardErrorEnvelope()
@@ -147,10 +148,10 @@ extension ErrorEnvelope.Exception: Decodable {
 extension ErrorEnvelope.KsrCode: Decodable {
   public static func decode(_ j: JSON) -> Decoded<ErrorEnvelope.KsrCode> {
     switch j {
-    case let .String(s):
+    case let .string(s):
       return pure(ErrorEnvelope.KsrCode(rawValue: s) ?? ErrorEnvelope.KsrCode.UnknownCode)
     default:
-      return .typeMismatch("ErrorEnvelope.KsrCode", actual: j)
+      return .typeMismatch(expected: "ErrorEnvelope.KsrCode", actual: j)
     }
   }
 }
@@ -168,7 +169,7 @@ extension ErrorEnvelope.FacebookUser: Decodable {
 // always returns a successfully decoded value.
 private func concatSuccesses<A>(_ decodeds: [Decoded<[A]>]) -> Decoded<[A]> {
 
-  return decodeds.reduce(Decoded.Success([])) { accum, decoded in
-    .Success( (accum.value ?? []) + (decoded.value ?? []) )
+  return decodeds.reduce(Decoded.success([])) { accum, decoded in
+    .success( (accum.value ?? []) + (decoded.value ?? []) )
   }
 }

--- a/KsApi/models/FindFriendsEnvelope.swift
+++ b/KsApi/models/FindFriendsEnvelope.swift
@@ -16,7 +16,7 @@ public struct FindFriendsEnvelope {
 }
 
 extension FindFriendsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<FindFriendsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<FindFriendsEnvelope> {
     return curry(FindFriendsEnvelope.init)
       <^> json <|   "contacts_imported"
       <*> json <|   "urls"
@@ -25,14 +25,14 @@ extension FindFriendsEnvelope: Decodable {
 }
 
 extension FindFriendsEnvelope.UrlsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<FindFriendsEnvelope.UrlsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<FindFriendsEnvelope.UrlsEnvelope> {
     return curry(FindFriendsEnvelope.UrlsEnvelope.init)
       <^> json <| "api"
   }
 }
 
 extension FindFriendsEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<FindFriendsEnvelope.UrlsEnvelope.ApiEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<FindFriendsEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(FindFriendsEnvelope.UrlsEnvelope.ApiEnvelope.init)
       <^> json <|? "more_users"
   }

--- a/KsApi/models/FindFriendsEnvelope.swift
+++ b/KsApi/models/FindFriendsEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct FindFriendsEnvelope {
   public let contactsImported: Bool
@@ -20,7 +21,7 @@ extension FindFriendsEnvelope: Decodable {
     return curry(FindFriendsEnvelope.init)
       <^> json <|   "contacts_imported"
       <*> json <|   "urls"
-      <*> (json <|| "users") <|> .Success([])
+      <*> (json <|| "users" <|> .success([]))
   }
 }
 

--- a/KsApi/models/FriendStatsEnvelope.swift
+++ b/KsApi/models/FriendStatsEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct FriendStatsEnvelope {
   public let stats: Stats

--- a/KsApi/models/FriendStatsEnvelope.swift
+++ b/KsApi/models/FriendStatsEnvelope.swift
@@ -11,14 +11,14 @@ public struct FriendStatsEnvelope {
 }
 
 extension FriendStatsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<FriendStatsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<FriendStatsEnvelope> {
     return curry(FriendStatsEnvelope.init)
       <^> json <| "stats"
   }
 }
 
 extension FriendStatsEnvelope.Stats: Decodable {
-  public static func decode(json: JSON) -> Decoded<FriendStatsEnvelope.Stats> {
+  public static func decode(_ json: JSON) -> Decoded<FriendStatsEnvelope.Stats> {
     return curry(FriendStatsEnvelope.Stats.init)
       <^> json <| "friend_projects_count"
       <*> json <| "remote_friends_count"

--- a/KsApi/models/Item.swift
+++ b/KsApi/models/Item.swift
@@ -11,7 +11,7 @@ public struct Item {
 }
 
 extension Item: Decodable {
-  public static func decode(json: JSON) -> Decoded<Item> {
+  public static func decode(_ json: JSON) -> Decoded<Item> {
     let create = curry(Item.init)
     return create
       <^> json <| "amount"

--- a/KsApi/models/Item.swift
+++ b/KsApi/models/Item.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct Item {
   public let amount: Float

--- a/KsApi/models/Location.swift
+++ b/KsApi/models/Location.swift
@@ -27,12 +27,12 @@ extension Location: Decodable {
 }
 
 extension Location: EncodableType {
-  public func encode() -> [String: Any] {
-    var result: [String: AnyObject] = [:]
-    result["country"] = self.country as AnyObject?
-    result["displayable_name"] = self.displayableName as AnyObject?
-    result["id"] = self.id as AnyObject?
-    result["name"] = self.name as AnyObject?
+  public func encode() -> [String:Any] {
+    var result: [String:Any] = [:]
+    result["country"] = self.country
+    result["displayable_name"] = self.displayableName
+    result["id"] = self.id
+    result["name"] = self.name
     return result
   }
 }

--- a/KsApi/models/Location.swift
+++ b/KsApi/models/Location.swift
@@ -16,7 +16,7 @@ public func == (lhs: Location, rhs: Location) -> Bool {
 }
 
 extension Location: Decodable {
-  static public func decode(json: JSON) -> Decoded<Location> {
+  static public func decode(_ json: JSON) -> Decoded<Location> {
     return curry(Location.init)
       <^> json <| "country"
       <*> json <| "displayable_name"
@@ -28,10 +28,10 @@ extension Location: Decodable {
 extension Location: EncodableType {
   public func encode() -> [String: AnyObject] {
     var result: [String: AnyObject] = [:]
-    result["country"] = self.country
-    result["displayable_name"] = self.displayableName
-    result["id"] = self.id
-    result["name"] = self.name
+    result["country"] = self.country as AnyObject?
+    result["displayable_name"] = self.displayableName as AnyObject?
+    result["id"] = self.id as AnyObject?
+    result["name"] = self.name as AnyObject?
     return result
   }
 }

--- a/KsApi/models/Location.swift
+++ b/KsApi/models/Location.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct Location {
   public let country: String
@@ -26,7 +27,7 @@ extension Location: Decodable {
 }
 
 extension Location: EncodableType {
-  public func encode() -> [String: AnyObject] {
+  public func encode() -> [String: Any] {
     var result: [String: AnyObject] = [:]
     result["country"] = self.country as AnyObject?
     result["displayable_name"] = self.displayableName as AnyObject?

--- a/KsApi/models/Message.swift
+++ b/KsApi/models/Message.swift
@@ -4,14 +4,14 @@ import Foundation
 
 public struct Message {
   public let body: String
-  public let createdAt: NSTimeInterval
+  public let createdAt: TimeInterval
   public let id: Int
   public let recipient: User
   public let sender: User
 }
 
 extension Message: Decodable {
-  public static func decode(json: JSON) -> Decoded<Message> {
+  public static func decode(_ json: JSON) -> Decoded<Message> {
     let create = curry(Message.init)
     return create
       <^> json <| "body"

--- a/KsApi/models/Message.swift
+++ b/KsApi/models/Message.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 import Foundation
 
 public struct Message {

--- a/KsApi/models/MessageSubject.swift
+++ b/KsApi/models/MessageSubject.swift
@@ -1,4 +1,4 @@
-import ReactiveCocoa
+import ReactiveSwift
 
 public enum MessageSubject {
   case backing(Backing)

--- a/KsApi/models/MessageSubject.swift
+++ b/KsApi/models/MessageSubject.swift
@@ -1,5 +1,3 @@
-import ReactiveSwift
-
 public enum MessageSubject {
   case backing(Backing)
   case messageThread(MessageThread)

--- a/KsApi/models/MessageThread.swift
+++ b/KsApi/models/MessageThread.swift
@@ -12,7 +12,7 @@ public struct MessageThread {
 }
 
 extension MessageThread: Decodable {
-  public static func decode(json: JSON) -> Decoded<MessageThread> {
+  public static func decode(_ json: JSON) -> Decoded<MessageThread> {
     let create = curry(MessageThread.init)
     let tmp = create
       <^> json <|? "backing"

--- a/KsApi/models/MessageThread.swift
+++ b/KsApi/models/MessageThread.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct MessageThread {
   public let backing: Backing?

--- a/KsApi/models/MessageThreadEnvelope.swift
+++ b/KsApi/models/MessageThreadEnvelope.swift
@@ -8,7 +8,7 @@ public struct MessageThreadEnvelope {
 }
 
 extension MessageThreadEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<MessageThreadEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<MessageThreadEnvelope> {
     return curry(MessageThreadEnvelope.init)
       <^> json <|| "participants"
       <*> json <|| "messages"

--- a/KsApi/models/MessageThreadEnvelope.swift
+++ b/KsApi/models/MessageThreadEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct MessageThreadEnvelope {
   public let participants: [User]

--- a/KsApi/models/MessageThreadsEnvelope.swift
+++ b/KsApi/models/MessageThreadsEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct MessageThreadsEnvelope {
   public let messageThreads: [MessageThread]

--- a/KsApi/models/MessageThreadsEnvelope.swift
+++ b/KsApi/models/MessageThreadsEnvelope.swift
@@ -15,7 +15,7 @@ public struct MessageThreadsEnvelope {
 }
 
 extension MessageThreadsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<MessageThreadsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<MessageThreadsEnvelope> {
     return curry(MessageThreadsEnvelope.init)
       <^> json <|| "message_threads"
       <*> json <| "urls"
@@ -23,14 +23,14 @@ extension MessageThreadsEnvelope: Decodable {
 }
 
 extension MessageThreadsEnvelope.UrlsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<MessageThreadsEnvelope.UrlsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<MessageThreadsEnvelope.UrlsEnvelope> {
     return curry(MessageThreadsEnvelope.UrlsEnvelope.init)
       <^> json <| "api"
   }
 }
 
 extension MessageThreadsEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<MessageThreadsEnvelope.UrlsEnvelope.ApiEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<MessageThreadsEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(MessageThreadsEnvelope.UrlsEnvelope.ApiEnvelope.init)
       <^> json <| "more_message_threads"
   }

--- a/KsApi/models/Param.swift
+++ b/KsApi/models/Param.swift
@@ -59,12 +59,12 @@ public func == (lhs: Param, rhs: Param) -> Bool {
 extension Param: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Param> {
     switch json {
-    case let .String(slug):
-      return .Success(.slug(slug))
-    case let .Number(number):
-      return .Success(.id(number.integerValue))
+    case let .string(slug):
+      return .success(.slug(slug))
+    case let .number(number):
+      return .success(.id(number.intValue))
     default:
-      return .Failure(.Custom("Param must be a number or string."))
+      return .failure(.custom("Param must be a number or string."))
     }
   }
 }

--- a/KsApi/models/Param.swift
+++ b/KsApi/models/Param.swift
@@ -70,9 +70,9 @@ extension Param: Decodable {
 }
 
 private let allowableRFC3986: CharacterSet = {
-  let set = NSMutableCharacterSet.alphanumeric()
-  set.addCharacters(in: "-._~/?")
-  return set as CharacterSet
+  var set = CharacterSet.alphanumerics
+  set.insert(charactersIn: "-._~/?")
+  return set
 }()
 
 private func encodeForRFC3986(_ str: String) -> String? {

--- a/KsApi/models/Param.swift
+++ b/KsApi/models/Param.swift
@@ -57,7 +57,7 @@ public func == (lhs: Param, rhs: Param) -> Bool {
 }
 
 extension Param: Decodable {
-  public static func decode(json: JSON) -> Decoded<Param> {
+  public static func decode(_ json: JSON) -> Decoded<Param> {
     switch json {
     case let .String(slug):
       return .Success(.slug(slug))
@@ -69,12 +69,12 @@ extension Param: Decodable {
   }
 }
 
-private let allowableRFC3986: NSCharacterSet = {
-  let set = NSMutableCharacterSet.alphanumericCharacterSet()
-  set.addCharactersInString("-._~/?")
-  return set
+private let allowableRFC3986: CharacterSet = {
+  let set = NSMutableCharacterSet.alphanumeric()
+  set.addCharacters(in: "-._~/?")
+  return set as CharacterSet
 }()
 
-private func encodeForRFC3986(str: String) -> String? {
-  return str.stringByAddingPercentEncodingWithAllowedCharacters(allowableRFC3986)
+private func encodeForRFC3986(_ str: String) -> String? {
+  return str.addingPercentEncoding(withAllowedCharacters: allowableRFC3986)
 }

--- a/KsApi/models/Project.Country.swift
+++ b/KsApi/models/Project.Country.swift
@@ -54,12 +54,12 @@ extension Project.Country: Decodable {
 }
 
 extension Project.Country: EncodableType {
-  public func encode() -> [String : Any] {
-    var result: [String:AnyObject] = [:]
-    result["country"] = self.countryCode as AnyObject?
-    result["currency"] = self.currencyCode as AnyObject?
-    result["currency_symbol"] = self.currencySymbol as AnyObject?
-    result["currency_trailing_code"] = self.trailingCode as AnyObject?
+  public func encode() -> [String:Any] {
+    var result: [String:Any] = [:]
+    result["country"] = self.countryCode
+    result["currency"] = self.currencyCode
+    result["currency_symbol"] = self.currencySymbol
+    result["currency_trailing_code"] = self.trailingCode
     return result
   }
 }

--- a/KsApi/models/Project.Country.swift
+++ b/KsApi/models/Project.Country.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 extension Project {
   public struct Country {
@@ -53,7 +54,7 @@ extension Project.Country: Decodable {
 }
 
 extension Project.Country: EncodableType {
-  public func encode() -> [String : AnyObject] {
+  public func encode() -> [String : Any] {
     var result: [String:AnyObject] = [:]
     result["country"] = self.countryCode as AnyObject?
     result["currency"] = self.currencyCode as AnyObject?

--- a/KsApi/models/Project.Country.swift
+++ b/KsApi/models/Project.Country.swift
@@ -39,7 +39,7 @@ extension Project {
 }
 
 extension Project.Country: Decodable {
-  public static func decode(json: JSON) -> Decoded<Project.Country> {
+  public static func decode(_ json: JSON) -> Decoded<Project.Country> {
     let create = curry(Project.Country.init)
 
     return create
@@ -55,10 +55,10 @@ extension Project.Country: Decodable {
 extension Project.Country: EncodableType {
   public func encode() -> [String : AnyObject] {
     var result: [String:AnyObject] = [:]
-    result["country"] = self.countryCode
-    result["currency"] = self.currencyCode
-    result["currency_symbol"] = self.currencySymbol
-    result["currency_trailing_code"] = self.trailingCode
+    result["country"] = self.countryCode as AnyObject?
+    result["currency"] = self.currencyCode as AnyObject?
+    result["currency_symbol"] = self.currencySymbol as AnyObject?
+    result["currency_trailing_code"] = self.trailingCode as AnyObject?
     return result
   }
 }

--- a/KsApi/models/Project.Video.swift
+++ b/KsApi/models/Project.Video.swift
@@ -9,7 +9,7 @@ extension Project {
 }
 
 extension Project.Video: Decodable {
-  public static func decode(json: JSON) -> Decoded<Project.Video> {
+  public static func decode(_ json: JSON) -> Decoded<Project.Video> {
     return curry(Project.Video.init)
       <^> json <| "id"
       <*> json <| "high"

--- a/KsApi/models/Project.Video.swift
+++ b/KsApi/models/Project.Video.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 extension Project {
   public struct Video {

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 import Prelude
 
 public struct Project {
@@ -154,12 +155,12 @@ extension Project: Decodable {
       <*> Project.MemberData.decode(json)
       <*> Project.Dates.decode(json)
       <*> json <| "id"
-      <*> (json <| "location" <|> .Success(Location.none))
+      <*> (json <| "location" <|> .success(Location.none))
       <*> json <| "name"
       <*> Project.Personalization.decode(json)
     return tmp2
       <*> json <| "photo"
-      <*> (json <|| "rewards" <|> .Success([]))
+      <*> (json <|| "rewards" <|> .success([]))
       <*> json <| "slug"
       <*> json <| "state"
       <*> Project.Stats.decode(json)
@@ -185,21 +186,23 @@ extension Project.UrlsEnvelope.WebEnvelope: Decodable {
 
 extension Project.Stats: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.Stats> {
-    return curry(Project.Stats.init)
+    let create = curry(Project.Stats.init)
+    return create
       <^> json <| "backers_count"
       <*> json <|? "comments_count"
       <*> json <| "goal"
       <*> json <| "pledged"
-      <*> (json <| "static_usd_rate") <|> .Success(1.0)
+      <*> (json <| "static_usd_rate" <|> .success(1.0))
       <*> json <|? "updates_count"
   }
 }
 
 extension Project.MemberData: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.MemberData> {
-    return curry(Project.MemberData.init)
+    let create = curry(Project.MemberData.init)
+    return create
       <^> json <|? "last_update_published_at"
-      <*> (removeUnknowns <^> (json <|| "permissions") <|> .Success([]))
+      <*> (removeUnknowns <^> (json <|| "permissions") <|> .success([]))
       <*> json <|? "unread_messages_count"
       <*> json <|? "unseen_activity_count"
   }
@@ -233,7 +236,7 @@ extension Project.Photo: Decodable {
     let url1024: Decoded<String?> = ((json <| "1024x768") <|> (json <| "1024x576"))
       // swiftlint:disable:next syntactic_sugar
       .map(Optional<String>.init)
-      <|> .Success(nil)
+      <|> .success(nil)
 
     return create
       <^> json <| "full"
@@ -245,10 +248,10 @@ extension Project.Photo: Decodable {
 
 extension Project.MemberData.Permission: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.MemberData.Permission> {
-    if case .String(let permission) = json {
-      return self.init(rawValue: permission).map(pure) ?? .Success(.unknown)
+    if case .string(let permission) = json {
+      return self.init(rawValue: permission).map(pure) ?? .success(.unknown)
     }
-    return .Success(.unknown)
+    return .success(.unknown)
   }
 }
 

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -126,7 +126,7 @@ public struct Project {
     return isDateToday(date: potdAt, today: today, calendar: calendar)
   }
 
-  fileprivate func isDateToday(date: TimeInterval, today: Date, calendar: Calendar) -> Bool {
+  private func isDateToday(date: TimeInterval, today: Date, calendar: Calendar) -> Bool {
     let startOfToday = calendar.startOfDay(for: today)
     return abs(startOfToday.timeIntervalSince1970 - date) < 60.0 * 60.0 * 24.0
   }

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -209,7 +209,7 @@ extension Project.Stats: Decodable {
 extension Project.LiveStream: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.LiveStream> {
     return curry(Project.LiveStream.init)
-      <^> (json <| "id" >>- toInt(string:)) <|> (json <| "id")
+      <^> ((json <| "id" >>- toInt(string:)) <|> (json <| "id"))
       <*> json <| "live_now"
       <*> json <| "name"
       <*> json <| "start_date"

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -278,7 +278,7 @@ private func removeUnknowns(_ xs: [Project.MemberData.Permission]) -> [Project.M
   return xs.filter { $0 != .unknown }
 }
 
-private func toInt(string string: String) -> Decoded<Int> {
-  return Int(string).map(Decoded.Success)
-    ?? Decoded.Failure(DecodeError.Custom("Couldn't decoded \"\(string)\" into Int."))
+private func toInt(string: String) -> Decoded<Int> {
+  return Int(string).map(Decoded.success)
+    ?? Decoded.failure(DecodeError.custom("Couldn't decoded \"\(string)\" into Int."))
 }

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -77,7 +77,7 @@ public struct Project {
     public let id: String
     public let isLiveNow: Bool
     public let name: String
-    public let startDate: NSTimeInterval
+    public let startDate: TimeInterval
     public let url: String
   }
 
@@ -164,7 +164,7 @@ extension Project: Decodable {
       <*> Project.MemberData.decode(json)
       <*> Project.Dates.decode(json)
       <*> json <| "id"
-      <*> (json <|| "livestreams" <|> .Success([]))
+      <*> (json <|| "livestreams" <|> .success([]))
       <*> (json <| "location" <|> .success(Location.none))
       <*> json <| "name"
       <*> Project.Personalization.decode(json)
@@ -208,7 +208,7 @@ extension Project.Stats: Decodable {
 }
 
 extension Project.LiveStream: Decodable {
-  public static func decode(json: JSON) -> Decoded<Project.LiveStream> {
+  public static func decode(_ json: JSON) -> Decoded<Project.LiveStream> {
     return curry(Project.LiveStream.init)
       <^> json <| "id"
       <*> json <| "live_now"

--- a/KsApi/models/ProjectActivityEnvelope.swift
+++ b/KsApi/models/ProjectActivityEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct ProjectActivityEnvelope {
   public let activities: [Activity]
@@ -32,6 +33,6 @@ extension ProjectActivityEnvelope.UrlsEnvelope: Decodable {
 extension ProjectActivityEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectActivityEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(ProjectActivityEnvelope.UrlsEnvelope.ApiEnvelope.init)
-      <^> json <| "more_activities" <|> .Success("")
+      <^> (json <| "more_activities" <|> .success(""))
   }
 }

--- a/KsApi/models/ProjectActivityEnvelope.swift
+++ b/KsApi/models/ProjectActivityEnvelope.swift
@@ -15,7 +15,7 @@ public struct ProjectActivityEnvelope {
 }
 
 extension ProjectActivityEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<ProjectActivityEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<ProjectActivityEnvelope> {
     return curry(ProjectActivityEnvelope.init)
       <^> json <|| "activities"
       <*> json <|  "urls"
@@ -23,14 +23,14 @@ extension ProjectActivityEnvelope: Decodable {
 }
 
 extension ProjectActivityEnvelope.UrlsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<ProjectActivityEnvelope.UrlsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<ProjectActivityEnvelope.UrlsEnvelope> {
     return curry(ProjectActivityEnvelope.UrlsEnvelope.init)
       <^> json <| "api"
   }
 }
 
 extension ProjectActivityEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<ProjectActivityEnvelope.UrlsEnvelope.ApiEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<ProjectActivityEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(ProjectActivityEnvelope.UrlsEnvelope.ApiEnvelope.init)
       <^> json <| "more_activities" <|> .Success("")
   }

--- a/KsApi/models/ProjectNotification.swift
+++ b/KsApi/models/ProjectNotification.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 import Foundation
 
 public struct ProjectNotification {

--- a/KsApi/models/ProjectNotification.swift
+++ b/KsApi/models/ProjectNotification.swift
@@ -15,7 +15,7 @@ public struct ProjectNotification {
 }
 
 extension ProjectNotification: Decodable {
-  public static func decode(json: JSON) -> Decoded<ProjectNotification> {
+  public static func decode(_ json: JSON) -> Decoded<ProjectNotification> {
     let create = curry(ProjectNotification.init)
     return create
       <^> json <| "email"
@@ -26,7 +26,7 @@ extension ProjectNotification: Decodable {
 }
 
 extension ProjectNotification.Project: Decodable {
-  public static func decode(json: JSON) -> Decoded<ProjectNotification.Project> {
+  public static func decode(_ json: JSON) -> Decoded<ProjectNotification.Project> {
     return curry(ProjectNotification.Project.init)
       <^> json <| "id"
       <*> json <| "name"

--- a/KsApi/models/ProjectStatsEnvelope.swift
+++ b/KsApi/models/ProjectStatsEnvelope.swift
@@ -20,7 +20,7 @@ public struct ProjectStatsEnvelope {
     public let backersCount: Int
     public let cumulativePledged: Int
     public let cumulativeBackersCount: Int
-    public let date: NSTimeInterval
+    public let date: TimeInterval
     public let pledged: Int
   }
 
@@ -58,7 +58,7 @@ public struct ProjectStatsEnvelope {
 }
 
 extension ProjectStatsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<ProjectStatsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<ProjectStatsEnvelope> {
     return curry(ProjectStatsEnvelope.init)
       <^> json <| "cumulative"
       <*> decodedJSON(json, forKey: "funding_distribution").flatMap(decodeSuccessfulFundingStats)
@@ -69,7 +69,7 @@ extension ProjectStatsEnvelope: Decodable {
 }
 
 extension ProjectStatsEnvelope.CumulativeStats: Decodable {
-  public static func decode(json: JSON) -> Decoded<ProjectStatsEnvelope.CumulativeStats> {
+  public static func decode(_ json: JSON) -> Decoded<ProjectStatsEnvelope.CumulativeStats> {
     return curry(ProjectStatsEnvelope.CumulativeStats.init)
       <^> json <| "average_pledge"
       <*> json <| "backers_count"
@@ -86,7 +86,7 @@ public func == (lhs: ProjectStatsEnvelope.CumulativeStats, rhs: ProjectStatsEnve
 }
 
 extension ProjectStatsEnvelope.FundingDateStats: Decodable {
-  public static func decode(json: JSON) -> Decoded<ProjectStatsEnvelope.FundingDateStats> {
+  public static func decode(_ json: JSON) -> Decoded<ProjectStatsEnvelope.FundingDateStats> {
     return curry(ProjectStatsEnvelope.FundingDateStats.init)
       <^> (json <| "backers_count" <|> .Success(0))
       <*> ((json <| "cumulative_pledged" >>- stringToIntOrZero) <|> (json <| "cumulative_pledged"))
@@ -103,7 +103,7 @@ public func == (lhs: ProjectStatsEnvelope.FundingDateStats, rhs: ProjectStatsEnv
 }
 
 extension ProjectStatsEnvelope.ReferrerStats: Decodable {
-  public static func decode(json: JSON) -> Decoded<ProjectStatsEnvelope.ReferrerStats> {
+  public static func decode(_ json: JSON) -> Decoded<ProjectStatsEnvelope.ReferrerStats> {
     return curry(ProjectStatsEnvelope.ReferrerStats.init)
       <^> json <| "backers_count"
       <*> json <| "code"
@@ -120,7 +120,7 @@ public func == (lhs: ProjectStatsEnvelope.ReferrerStats, rhs: ProjectStatsEnvelo
 }
 
 extension ProjectStatsEnvelope.ReferrerStats.ReferrerType: Decodable {
-  public static func decode(json: JSON) -> Decoded<ProjectStatsEnvelope.ReferrerStats.ReferrerType> {
+  public static func decode(_ json: JSON) -> Decoded<ProjectStatsEnvelope.ReferrerStats.ReferrerType> {
     if case .String(let referrerType) = json {
       switch referrerType.lowercaseString {
       case "custom":
@@ -138,7 +138,7 @@ extension ProjectStatsEnvelope.ReferrerStats.ReferrerType: Decodable {
 }
 
 extension ProjectStatsEnvelope.RewardStats: Decodable {
-  public static func decode(json: JSON) -> Decoded<ProjectStatsEnvelope.RewardStats> {
+  public static func decode(_ json: JSON) -> Decoded<ProjectStatsEnvelope.RewardStats> {
     return curry(ProjectStatsEnvelope.RewardStats.init)
       <^> json <| "backers_count"
       <*> json <| "reward_id"
@@ -154,7 +154,7 @@ public func == (lhs: ProjectStatsEnvelope.RewardStats, rhs: ProjectStatsEnvelope
 }
 
 extension ProjectStatsEnvelope.VideoStats: Decodable {
-  public static func decode(json: JSON) -> Decoded<ProjectStatsEnvelope.VideoStats> {
+  public static func decode(_ json: JSON) -> Decoded<ProjectStatsEnvelope.VideoStats> {
     let create = curry(ProjectStatsEnvelope.VideoStats.init)
     return create
       <^> json <| "external_completions"
@@ -173,7 +173,7 @@ public func == (lhs: ProjectStatsEnvelope.VideoStats, rhs: ProjectStatsEnvelope.
     lhs.internalStarts == rhs.internalStarts
 }
 
-private func decodeSuccessfulFundingStats(json: JSON) -> Decoded<[ProjectStatsEnvelope.FundingDateStats]> {
+private func decodeSuccessfulFundingStats(_ json: JSON) -> Decoded<[ProjectStatsEnvelope.FundingDateStats]> {
   switch json {
   case let .Array(arrayJSON):
     let decodeds = arrayJSON
@@ -185,14 +185,14 @@ private func decodeSuccessfulFundingStats(json: JSON) -> Decoded<[ProjectStatsEn
   }
 }
 
-private func stringToIntOrZero(string: String) -> Decoded<Int> {
+private func stringToIntOrZero(_ string: String) -> Decoded<Int> {
   return
     Double(string).flatMap(Int.init).map(Decoded.Success)
       ?? Int(string).map(Decoded.Success)
       ?? .Success(0)
 }
 
-private func stringToInt(string: String?) -> Decoded<Int?> {
+private func stringToInt(_ string: String?) -> Decoded<Int?> {
   guard let string = string else { return .Success(nil) }
 
   return
@@ -201,6 +201,6 @@ private func stringToInt(string: String?) -> Decoded<Int?> {
       ?? .Failure(.Custom("Could not parse string into int."))
 }
 
-private func stringToDouble(string: String) -> Decoded<Double> {
+private func stringToDouble(_ string: String) -> Decoded<Double> {
   return Double(string).map(Decoded.Success) ?? .Success(0)
 }

--- a/KsApi/models/ProjectsEnvelope.swift
+++ b/KsApi/models/ProjectsEnvelope.swift
@@ -15,7 +15,7 @@ public struct ProjectsEnvelope {
 }
 
 extension ProjectsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<ProjectsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<ProjectsEnvelope> {
     return curry(ProjectsEnvelope.init)
       <^> json <|| "projects"
       <*> json <| "urls"
@@ -23,14 +23,14 @@ extension ProjectsEnvelope: Decodable {
 }
 
 extension ProjectsEnvelope.UrlsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<ProjectsEnvelope.UrlsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<ProjectsEnvelope.UrlsEnvelope> {
     return curry(ProjectsEnvelope.UrlsEnvelope.init)
       <^> json <| "api"
   }
 }
 
 extension ProjectsEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<ProjectsEnvelope.UrlsEnvelope.ApiEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<ProjectsEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(ProjectsEnvelope.UrlsEnvelope.ApiEnvelope.init)
       <^> json <| "more_projects" <|> .Success("")
   }

--- a/KsApi/models/ProjectsEnvelope.swift
+++ b/KsApi/models/ProjectsEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct ProjectsEnvelope {
   public let projects: [Project]
@@ -32,6 +33,6 @@ extension ProjectsEnvelope.UrlsEnvelope: Decodable {
 extension ProjectsEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectsEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(ProjectsEnvelope.UrlsEnvelope.ApiEnvelope.init)
-      <^> json <| "more_projects" <|> .Success("")
+      <^> (json <| "more_projects" <|> .success(""))
   }
 }

--- a/KsApi/models/PushEnvelope.swift
+++ b/KsApi/models/PushEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct PushEnvelope {
   public let activity: Activity?
@@ -50,7 +51,7 @@ extension PushEnvelope: Decodable {
     let create = curry(PushEnvelope.init)
 
     let update: Decoded<Update> = json <| "update" <|> json <| "post"
-    let optionalUpdate: Decoded<Update?> = update.map(Optional.Some) <|> .Success(nil)
+    let optionalUpdate: Decoded<Update?> = update.map(Optional.some) <|> .success(nil)
 
     return create
       <^> json <|? "activity"

--- a/KsApi/models/PushEnvelope.swift
+++ b/KsApi/models/PushEnvelope.swift
@@ -46,7 +46,7 @@ public struct PushEnvelope {
 }
 
 extension PushEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<PushEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<PushEnvelope> {
     let create = curry(PushEnvelope.init)
 
     let update: Decoded<Update> = json <| "update" <|> json <| "post"
@@ -64,7 +64,7 @@ extension PushEnvelope: Decodable {
 }
 
 extension PushEnvelope.Activity: Decodable {
-  public static func decode(json: JSON) -> Decoded<PushEnvelope.Activity> {
+  public static func decode(_ json: JSON) -> Decoded<PushEnvelope.Activity> {
     let create = curry(PushEnvelope.Activity.init)
     return create
       <^> json <| "category"
@@ -78,14 +78,14 @@ extension PushEnvelope.Activity: Decodable {
 }
 
 extension PushEnvelope.ApsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<PushEnvelope.ApsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<PushEnvelope.ApsEnvelope> {
     return curry(PushEnvelope.ApsEnvelope.init)
       <^> json <| "alert"
   }
 }
 
 extension PushEnvelope.Message: Decodable {
-  public static func decode(json: JSON) -> Decoded<PushEnvelope.Message> {
+  public static func decode(_ json: JSON) -> Decoded<PushEnvelope.Message> {
     return curry(PushEnvelope.Message.init)
       <^> json <| "message_thread_id"
       <*> json <| "project_id"
@@ -93,7 +93,7 @@ extension PushEnvelope.Message: Decodable {
 }
 
 extension PushEnvelope.Project: Decodable {
-  public static func decode(json: JSON) -> Decoded<PushEnvelope.Project> {
+  public static func decode(_ json: JSON) -> Decoded<PushEnvelope.Project> {
     return curry(PushEnvelope.Project.init)
       <^> json <| "id"
       <*> json <|? "photo"
@@ -101,7 +101,7 @@ extension PushEnvelope.Project: Decodable {
 }
 
 extension PushEnvelope.Survey: Decodable {
-  public static func decode(json: JSON) -> Decoded<PushEnvelope.Survey> {
+  public static func decode(_ json: JSON) -> Decoded<PushEnvelope.Survey> {
     return curry(PushEnvelope.Survey.init)
       <^> json <| "id"
       <*> json <| "project_id"
@@ -109,7 +109,7 @@ extension PushEnvelope.Survey: Decodable {
 }
 
 extension PushEnvelope.Update: Decodable {
-  public static func decode(json: JSON) -> Decoded<PushEnvelope.Update> {
+  public static func decode(_ json: JSON) -> Decoded<PushEnvelope.Update> {
     return curry(PushEnvelope.Update.init)
       <^> json <| "id"
       <*> json <| "project_id"

--- a/KsApi/models/Reward.swift
+++ b/KsApi/models/Reward.swift
@@ -5,15 +5,15 @@ import Prelude
 public struct Reward {
   public let backersCount: Int?
   public let description: String
-  public let endsAt: NSTimeInterval?
-  public let estimatedDeliveryOn: NSTimeInterval?
+  public let endsAt: TimeInterval?
+  public let estimatedDeliveryOn: TimeInterval?
   public let id: Int
   public let limit: Int?
   public let minimum: Int
   public let remaining: Int?
   public let rewardsItems: [RewardsItem]
   public let shipping: Shipping
-  public let startsAt: NSTimeInterval?
+  public let startsAt: TimeInterval?
   public let title: String?
 
   /// Returns `true` is this is the "fake" "No reward" reward.
@@ -47,7 +47,7 @@ public func < (lhs: Reward, rhs: Reward) -> Bool {
 }
 
 extension Reward: Decodable {
-  public static func decode(json: JSON) -> Decoded<Reward> {
+  public static func decode(_ json: JSON) -> Decoded<Reward> {
     let create = curry(Reward.init)
     let tmp1 = create
       <^> json <|? "backers_count"
@@ -68,7 +68,7 @@ extension Reward: Decodable {
 }
 
 extension Reward.Shipping: Decodable {
-  public static func decode(json: JSON) -> Decoded<Reward.Shipping> {
+  public static func decode(_ json: JSON) -> Decoded<Reward.Shipping> {
     return curry(Reward.Shipping.init)
       <^> json <| "shipping_enabled" <|> .Success(false)
       <*> json <|? "shipping_preference"

--- a/KsApi/models/Reward.swift
+++ b/KsApi/models/Reward.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 import Prelude
 
 public struct Reward {
@@ -60,7 +61,7 @@ extension Reward: Decodable {
       <*> json <| "minimum"
       <*> json <|? "remaining"
     return tmp2
-      <*> ((json <|| "rewards_items") <|> .Success([]))
+      <*> ((json <|| "rewards_items") <|> .success([]))
       <*> Reward.Shipping.decode(json)
       <*> json <|? "starts_at"
       <*> json <|? "title"
@@ -70,7 +71,7 @@ extension Reward: Decodable {
 extension Reward.Shipping: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Reward.Shipping> {
     return curry(Reward.Shipping.init)
-      <^> json <| "shipping_enabled" <|> .Success(false)
+      <^> (json <| "shipping_enabled" <|> .success(false))
       <*> json <|? "shipping_preference"
       <*> json <|? "shipping_summary"
   }

--- a/KsApi/models/RewardsItem.swift
+++ b/KsApi/models/RewardsItem.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct RewardsItem {
   public let id: Int

--- a/KsApi/models/RewardsItem.swift
+++ b/KsApi/models/RewardsItem.swift
@@ -9,7 +9,7 @@ public struct RewardsItem {
 }
 
 extension RewardsItem: Decodable {
-  public static func decode(json: JSON) -> Decoded<RewardsItem> {
+  public static func decode(_ json: JSON) -> Decoded<RewardsItem> {
     return curry(RewardsItem.init)
       <^> json <| "id"
       <*> json <| "item"

--- a/KsApi/models/ShippingRule.swift
+++ b/KsApi/models/ShippingRule.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct ShippingRule {
   public let cost: Double
@@ -23,5 +24,5 @@ public func == (lhs: ShippingRule, rhs: ShippingRule) -> Bool {
 }
 
 private func stringToDouble(_ string: String) -> Decoded<Double> {
-  return Double(string).map(Decoded.Success) ?? .Success(0)
+  return Double(string).map(Decoded.success) ?? .success(0)
 }

--- a/KsApi/models/ShippingRule.swift
+++ b/KsApi/models/ShippingRule.swift
@@ -8,7 +8,7 @@ public struct ShippingRule {
 }
 
 extension ShippingRule: Decodable {
-  public static func decode(json: JSON) -> Decoded<ShippingRule> {
+  public static func decode(_ json: JSON) -> Decoded<ShippingRule> {
     return curry(ShippingRule.init)
       <^> (json <| "cost" >>- stringToDouble)
       <*> json <|? "id"
@@ -22,6 +22,6 @@ public func == (lhs: ShippingRule, rhs: ShippingRule) -> Bool {
   return lhs.location ==  rhs.location
 }
 
-private func stringToDouble(string: String) -> Decoded<Double> {
+private func stringToDouble(_ string: String) -> Decoded<Double> {
   return Double(string).map(Decoded.Success) ?? .Success(0)
 }

--- a/KsApi/models/ShippingRulesEnvelope.swift
+++ b/KsApi/models/ShippingRulesEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct ShippingRulesEnvelope {
   public let shippingRules: [ShippingRule]

--- a/KsApi/models/ShippingRulesEnvelope.swift
+++ b/KsApi/models/ShippingRulesEnvelope.swift
@@ -6,7 +6,7 @@ public struct ShippingRulesEnvelope {
 }
 
 extension ShippingRulesEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<ShippingRulesEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<ShippingRulesEnvelope> {
     return curry(ShippingRulesEnvelope.init)
       <^> json <|| "shipping_rules"
   }

--- a/KsApi/models/StarEnvelope.swift
+++ b/KsApi/models/StarEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct StarEnvelope {
   public let user: User

--- a/KsApi/models/StarEnvelope.swift
+++ b/KsApi/models/StarEnvelope.swift
@@ -7,7 +7,7 @@ public struct StarEnvelope {
 }
 
 extension StarEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<StarEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<StarEnvelope> {
     return curry(StarEnvelope.init)
       <^> json <| "user"
       <*> json <| "project"

--- a/KsApi/models/SubmitApplePayEnvelope.swift
+++ b/KsApi/models/SubmitApplePayEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct SubmitApplePayEnvelope {
   public let thankYouUrl: String
@@ -16,7 +17,7 @@ extension SubmitApplePayEnvelope: Decodable {
 
 private func stringToIntOrZero(_ string: String) -> Decoded<Int> {
   return
-    Double(string).flatMap(Int.init).map(Decoded.Success)
-      ?? Int(string).map(Decoded.Success)
-      ?? .Success(0)
+    Double(string).flatMap(Int.init).map(Decoded.success)
+      ?? Int(string).map(Decoded.success)
+      ?? .success(0)
 }

--- a/KsApi/models/SubmitApplePayEnvelope.swift
+++ b/KsApi/models/SubmitApplePayEnvelope.swift
@@ -7,14 +7,14 @@ public struct SubmitApplePayEnvelope {
 }
 
 extension SubmitApplePayEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<SubmitApplePayEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<SubmitApplePayEnvelope> {
     return curry(SubmitApplePayEnvelope.init)
       <^> json <| ["data", "thankyou_url"]
       <*> ((json <| "status" >>- stringToIntOrZero) <|> (json <| "status"))
   }
 }
 
-private func stringToIntOrZero(string: String) -> Decoded<Int> {
+private func stringToIntOrZero(_ string: String) -> Decoded<Int> {
   return
     Double(string).flatMap(Int.init).map(Decoded.Success)
       ?? Int(string).map(Decoded.Success)

--- a/KsApi/models/SurveyResponse.swift
+++ b/KsApi/models/SurveyResponse.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct SurveyResponse {
   public let answeredAt: TimeInterval?

--- a/KsApi/models/SurveyResponse.swift
+++ b/KsApi/models/SurveyResponse.swift
@@ -2,7 +2,7 @@ import Argo
 import Curry
 
 public struct SurveyResponse {
-  public let answeredAt: NSTimeInterval?
+  public let answeredAt: TimeInterval?
   public let id: Int
   public let project: Project?
   public let urls: UrlsEnvelope
@@ -22,7 +22,7 @@ public func == (lhs: SurveyResponse, rhs: SurveyResponse) -> Bool {
 }
 
 extension SurveyResponse: Decodable {
-  public static func decode(json: JSON) -> Decoded<SurveyResponse> {
+  public static func decode(_ json: JSON) -> Decoded<SurveyResponse> {
     return curry(SurveyResponse.init)
       <^> json <|? "answered_at"
       <*> json <| "id"
@@ -32,14 +32,14 @@ extension SurveyResponse: Decodable {
 }
 
 extension SurveyResponse.UrlsEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<SurveyResponse.UrlsEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<SurveyResponse.UrlsEnvelope> {
     return curry(SurveyResponse.UrlsEnvelope.init)
       <^> json <| "web"
   }
 }
 
 extension SurveyResponse.UrlsEnvelope.WebEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<SurveyResponse.UrlsEnvelope.WebEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<SurveyResponse.UrlsEnvelope.WebEnvelope> {
     return curry(SurveyResponse.UrlsEnvelope.WebEnvelope.init)
       <^> json <| "survey"
   }

--- a/KsApi/models/Update.swift
+++ b/KsApi/models/Update.swift
@@ -10,7 +10,7 @@ public struct Update {
   public let isPublic: Bool
   public let likesCount: Int?
   public let projectId: Int
-  public let publishedAt: NSTimeInterval?
+  public let publishedAt: TimeInterval?
   public let sequence: Int
   public let title: String
   public let urls: UrlsEnvelope
@@ -34,7 +34,7 @@ public func == (lhs: Update, rhs: Update) -> Bool {
 
 extension Update: Decodable {
 
-  public static func decode(json: JSON) -> Decoded<Update> {
+  public static func decode(_ json: JSON) -> Decoded<Update> {
     let create = curry(Update.init)
     let tmp = create
       <^> json <|?  "body"
@@ -55,14 +55,14 @@ extension Update: Decodable {
 }
 
 extension Update.UrlsEnvelope: Decodable {
-  static public func decode(json: JSON) -> Decoded<Update.UrlsEnvelope> {
+  static public func decode(_ json: JSON) -> Decoded<Update.UrlsEnvelope> {
     return curry(Update.UrlsEnvelope.init)
       <^> json <| "web"
   }
 }
 
 extension Update.UrlsEnvelope.WebEnvelope: Decodable {
-  static public func decode(json: JSON) -> Decoded<Update.UrlsEnvelope.WebEnvelope> {
+  static public func decode(_ json: JSON) -> Decoded<Update.UrlsEnvelope.WebEnvelope> {
     return curry(Update.UrlsEnvelope.WebEnvelope.init)
       <^> json <| "update"
   }

--- a/KsApi/models/Update.swift
+++ b/KsApi/models/Update.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Argo
 import Curry
+import Runes
 
 public struct Update {
   public let body: String?
@@ -47,7 +48,7 @@ extension Update: Decodable {
       <*> json <|  "project_id"
       <*> json <|? "published_at"
       <*> json <|  "sequence"
-      <*> json <| "title" <|> .Success("")
+      <*> (json <| "title" <|> .success(""))
       <*> json <|  "urls"
       <*> json <|? "user"
       <*> json <|?  "visible"

--- a/KsApi/models/UpdateDraft.swift
+++ b/KsApi/models/UpdateDraft.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct UpdateDraft {
   public let update: Update

--- a/KsApi/models/UpdateDraft.swift
+++ b/KsApi/models/UpdateDraft.swift
@@ -61,7 +61,7 @@ public func == (lhs: UpdateDraft.Attachment, rhs: UpdateDraft.Attachment) -> Boo
 }
 
 extension UpdateDraft: Decodable {
-  public static func decode(json: JSON) -> Decoded<UpdateDraft> {
+  public static func decode(_ json: JSON) -> Decoded<UpdateDraft> {
     return curry(UpdateDraft.init)
       <^> Update.decode(json)
       <*> json <|| "images"
@@ -70,7 +70,7 @@ extension UpdateDraft: Decodable {
 }
 
 extension UpdateDraft.Image: Decodable {
-  public static func decode(json: JSON) -> Decoded<UpdateDraft.Image> {
+  public static func decode(_ json: JSON) -> Decoded<UpdateDraft.Image> {
     return curry(UpdateDraft.Image.init)
       <^> json <| "id"
       <*> json <| "thumb"
@@ -79,7 +79,7 @@ extension UpdateDraft.Image: Decodable {
 }
 
 extension UpdateDraft.Video: Decodable {
-  public static func decode(json: JSON) -> Decoded<UpdateDraft.Video> {
+  public static func decode(_ json: JSON) -> Decoded<UpdateDraft.Video> {
     return curry(UpdateDraft.Video.init)
       <^> json <| "id"
       <*> json <| "status"

--- a/KsApi/models/UpdatePledgeEnvelope.swift
+++ b/KsApi/models/UpdatePledgeEnvelope.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct UpdatePledgeEnvelope {
   public let newCheckoutUrl: String?
@@ -16,7 +17,7 @@ extension UpdatePledgeEnvelope: Decodable {
 
 private func stringToIntOrZero(_ string: String) -> Decoded<Int> {
   return
-    Double(string).flatMap(Int.init).map(Decoded.Success)
-      ?? Int(string).map(Decoded.Success)
-      ?? .Success(0)
+    Double(string).flatMap(Int.init).map(Decoded.success)
+      ?? Int(string).map(Decoded.success)
+      ?? .success(0)
 }

--- a/KsApi/models/UpdatePledgeEnvelope.swift
+++ b/KsApi/models/UpdatePledgeEnvelope.swift
@@ -7,14 +7,14 @@ public struct UpdatePledgeEnvelope {
 }
 
 extension UpdatePledgeEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<UpdatePledgeEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<UpdatePledgeEnvelope> {
     return curry(UpdatePledgeEnvelope.init)
       <^> json <|? ["data", "new_checkout_url"]
       <*> ((json <| "status" >>- stringToIntOrZero) <|> (json <| "status"))
   }
 }
 
-private func stringToIntOrZero(string: String) -> Decoded<Int> {
+private func stringToIntOrZero(_ string: String) -> Decoded<Int> {
   return
     Double(string).flatMap(Int.init).map(Decoded.Success)
       ?? Int(string).map(Decoded.Success)

--- a/KsApi/models/User.swift
+++ b/KsApi/models/User.swift
@@ -67,7 +67,7 @@ extension User: CustomDebugStringConvertible {
 }
 
 extension User: Decodable {
-  public static func decode(json: JSON) -> Decoded<User> {
+  public static func decode(_ json: JSON) -> Decoded<User> {
     let create = curry(User.init)
     let tmp = create
       <^> json <| "avatar"
@@ -87,12 +87,12 @@ extension User: Decodable {
 extension User: EncodableType {
   public func encode() -> [String:AnyObject] {
     var result: [String:AnyObject] = [:]
-    result["avatar"] = self.avatar.encode()
-    result["facebook_connected"] = self.facebookConnected ?? false
-    result["id"] = self.id
-    result["is_friend"] = self.isFriend ?? false
-    result["location"] = self.location?.encode()
-    result["name"] = self.name
+    result["avatar"] = self.avatar.encode() as AnyObject?
+    result["facebook_connected"] = self.facebookConnected as AnyObject?? ?? false as AnyObject?
+    result["id"] = self.id as AnyObject?
+    result["is_friend"] = self.isFriend as AnyObject?? ?? false as AnyObject?
+    result["location"] = self.location?.encode() as AnyObject?
+    result["name"] = self.name as AnyObject?
     result = result.withAllValuesFrom(self.newsletters.encode())
     result = result.withAllValuesFrom(self.notifications.encode())
     result = result.withAllValuesFrom(self.stats.encode())
@@ -102,7 +102,7 @@ extension User: EncodableType {
 }
 
 extension User.Avatar: Decodable {
-  public static func decode(json: JSON) -> Decoded<User.Avatar> {
+  public static func decode(_ json: JSON) -> Decoded<User.Avatar> {
     return curry(User.Avatar.init)
       <^> json <|? "large"
       <*> json <| "medium"
@@ -119,12 +119,12 @@ extension User.Avatar: EncodableType {
 
     ret["large"] = self.large
 
-    return ret
+    return ret as [String : AnyObject]
   }
 }
 
 extension User.NewsletterSubscriptions: Decodable {
-  public static func decode(json: JSON) -> Decoded<User.NewsletterSubscriptions> {
+  public static func decode(_ json: JSON) -> Decoded<User.NewsletterSubscriptions> {
     return curry(User.NewsletterSubscriptions.init)
       <^> json <|? "games_newsletter"
       <*> json <|? "happening_newsletter"
@@ -136,10 +136,10 @@ extension User.NewsletterSubscriptions: Decodable {
 extension User.NewsletterSubscriptions: EncodableType {
   public func encode() -> [String: AnyObject] {
     var result: [String: AnyObject] = [:]
-    result["games_newsletter"] = self.games
-    result["happening_newsletter"] = self.happening
-    result["promo_newsletter"] = self.promo
-    result["weekly_newsletter"] = self.weekly
+    result["games_newsletter"] = self.games as AnyObject?
+    result["happening_newsletter"] = self.happening as AnyObject?
+    result["promo_newsletter"] = self.promo as AnyObject?
+    result["weekly_newsletter"] = self.weekly as AnyObject?
     return result
   }
 }
@@ -153,7 +153,7 @@ public func == (lhs: User.NewsletterSubscriptions, rhs: User.NewsletterSubscript
 }
 
 extension User.Notifications: Decodable {
-  public static func decode(json: JSON) -> Decoded<User.Notifications> {
+  public static func decode(_ json: JSON) -> Decoded<User.Notifications> {
     let create = curry(User.Notifications.init)
     let tmp1 = create
       <^> json <|? "notify_of_backings"
@@ -176,18 +176,18 @@ extension User.Notifications: Decodable {
 extension User.Notifications: EncodableType {
   public func encode() -> [String : AnyObject] {
     var result: [String: AnyObject] = [:]
-    result["notify_of_backings"] = self.backings
-    result["notify_of_comments"] = self.comments
-    result["notify_of_follower"] = self.follower
-    result["notify_of_friend_activity"] = self.friendActivity
-    result["notify_of_post_likes"] = self.postLikes
-    result["notify_of_updates"] = self.updates
-    result["notify_mobile_of_backings"] = self.mobileBackings
-    result["notify_mobile_of_comments"] = self.mobileComments
-    result["notify_mobile_of_follower"] = self.mobileFollower
-    result["notify_mobile_of_friend_activity"] = self.mobileFriendActivity
-    result["notify_mobile_of_post_likes"] = self.mobilePostLikes
-    result["notify_mobile_of_updates"] = self.mobileUpdates
+    result["notify_of_backings"] = self.backings as AnyObject?
+    result["notify_of_comments"] = self.comments as AnyObject?
+    result["notify_of_follower"] = self.follower as AnyObject?
+    result["notify_of_friend_activity"] = self.friendActivity as AnyObject?
+    result["notify_of_post_likes"] = self.postLikes as AnyObject?
+    result["notify_of_updates"] = self.updates as AnyObject?
+    result["notify_mobile_of_backings"] = self.mobileBackings as AnyObject?
+    result["notify_mobile_of_comments"] = self.mobileComments as AnyObject?
+    result["notify_mobile_of_follower"] = self.mobileFollower as AnyObject?
+    result["notify_mobile_of_friend_activity"] = self.mobileFriendActivity as AnyObject?
+    result["notify_mobile_of_post_likes"] = self.mobilePostLikes as AnyObject?
+    result["notify_mobile_of_updates"] = self.mobileUpdates as AnyObject?
     return result
   }
 }
@@ -209,7 +209,7 @@ public func == (lhs: User.Notifications, rhs: User.Notifications) -> Bool {
 }
 
 extension User.Stats: Decodable {
-  public static func decode(json: JSON) -> Decoded<User.Stats> {
+  public static func decode(_ json: JSON) -> Decoded<User.Stats> {
     let create = curry(User.Stats.init)
     return create
       <^> json <|? "backed_projects_count"
@@ -224,12 +224,12 @@ extension User.Stats: Decodable {
 extension User.Stats: EncodableType {
   public func encode() -> [String: AnyObject] {
     var result: [String: AnyObject] = [:]
-    result["backed_projects_count"] =  self.backedProjectsCount
-    result["created_projects_count"] = self.createdProjectsCount
-    result["member_projects_count"] = self.memberProjectsCount
-    result["starred_projects_count"] = self.starredProjectsCount
-    result["unanswered_surveys_count"] = self.unansweredSurveysCount
-    result["unread_messages_count"] =  self.unreadMessagesCount
+    result["backed_projects_count"] =  self.backedProjectsCount as AnyObject?
+    result["created_projects_count"] = self.createdProjectsCount as AnyObject?
+    result["member_projects_count"] = self.memberProjectsCount as AnyObject?
+    result["starred_projects_count"] = self.starredProjectsCount as AnyObject?
+    result["unanswered_surveys_count"] = self.unansweredSurveysCount as AnyObject?
+    result["unread_messages_count"] =  self.unreadMessagesCount as AnyObject?
     return result
   }
 }

--- a/KsApi/models/User.swift
+++ b/KsApi/models/User.swift
@@ -135,8 +135,8 @@ extension User.NewsletterSubscriptions: Decodable {
 }
 
 extension User.NewsletterSubscriptions: EncodableType {
-  public func encode() -> [String: Any] {
-    var result: [String: Any] = [:]
+  public func encode() -> [String:Any] {
+    var result: [String:Any] = [:]
     result["games_newsletter"] = self.games
     result["happening_newsletter"] = self.happening
     result["promo_newsletter"] = self.promo
@@ -175,8 +175,8 @@ extension User.Notifications: Decodable {
 }
 
 extension User.Notifications: EncodableType {
-  public func encode() -> [String : Any] {
-    var result: [String: Any] = [:]
+  public func encode() -> [String:Any] {
+    var result: [String:Any] = [:]
     result["notify_of_backings"] = self.backings
     result["notify_of_comments"] = self.comments
     result["notify_of_follower"] = self.follower
@@ -223,8 +223,8 @@ extension User.Stats: Decodable {
 }
 
 extension User.Stats: EncodableType {
-  public func encode() -> [String: Any] {
-    var result: [String: Any] = [:]
+  public func encode() -> [String:Any] {
+    var result: [String:Any] = [:]
     result["backed_projects_count"] =  self.backedProjectsCount
     result["created_projects_count"] = self.createdProjectsCount
     result["member_projects_count"] = self.memberProjectsCount

--- a/KsApi/models/User.swift
+++ b/KsApi/models/User.swift
@@ -1,5 +1,6 @@
 import Argo
 import Curry
+import Runes
 
 public struct User {
   public let avatar: Avatar
@@ -74,7 +75,7 @@ extension User: Decodable {
       <*> json <|? "facebook_connected"
       <*> json <| "id"
       <*> json <|? "is_friend"
-      <*> json <|? "location"
+      <*> (json <|? "location" <|> .success(nil))
     return tmp
       <*> json <| "name"
       <*> User.NewsletterSubscriptions.decode(json)
@@ -85,14 +86,14 @@ extension User: Decodable {
 }
 
 extension User: EncodableType {
-  public func encode() -> [String:AnyObject] {
-    var result: [String:AnyObject] = [:]
-    result["avatar"] = self.avatar.encode() as AnyObject?
-    result["facebook_connected"] = self.facebookConnected as AnyObject?? ?? false as AnyObject?
-    result["id"] = self.id as AnyObject?
-    result["is_friend"] = self.isFriend as AnyObject?? ?? false as AnyObject?
-    result["location"] = self.location?.encode() as AnyObject?
-    result["name"] = self.name as AnyObject?
+  public func encode() -> [String:Any] {
+    var result: [String:Any] = [:]
+    result["avatar"] = self.avatar.encode()
+    result["facebook_connected"] = self.facebookConnected ?? false
+    result["id"] = self.id
+    result["is_friend"] = self.isFriend ?? false
+    result["location"] = self.location?.encode()
+    result["name"] = self.name
     result = result.withAllValuesFrom(self.newsletters.encode())
     result = result.withAllValuesFrom(self.notifications.encode())
     result = result.withAllValuesFrom(self.stats.encode())
@@ -111,15 +112,15 @@ extension User.Avatar: Decodable {
 }
 
 extension User.Avatar: EncodableType {
-  public func encode() -> [String:AnyObject] {
-    var ret = [
+  public func encode() -> [String:Any] {
+    var ret: [String:Any] = [
       "medium": self.medium,
       "small": self.small
     ]
 
     ret["large"] = self.large
 
-    return ret as [String : AnyObject]
+    return ret
   }
 }
 
@@ -134,12 +135,12 @@ extension User.NewsletterSubscriptions: Decodable {
 }
 
 extension User.NewsletterSubscriptions: EncodableType {
-  public func encode() -> [String: AnyObject] {
-    var result: [String: AnyObject] = [:]
-    result["games_newsletter"] = self.games as AnyObject?
-    result["happening_newsletter"] = self.happening as AnyObject?
-    result["promo_newsletter"] = self.promo as AnyObject?
-    result["weekly_newsletter"] = self.weekly as AnyObject?
+  public func encode() -> [String: Any] {
+    var result: [String: Any] = [:]
+    result["games_newsletter"] = self.games
+    result["happening_newsletter"] = self.happening
+    result["promo_newsletter"] = self.promo
+    result["weekly_newsletter"] = self.weekly
     return result
   }
 }
@@ -174,20 +175,20 @@ extension User.Notifications: Decodable {
 }
 
 extension User.Notifications: EncodableType {
-  public func encode() -> [String : AnyObject] {
-    var result: [String: AnyObject] = [:]
-    result["notify_of_backings"] = self.backings as AnyObject?
-    result["notify_of_comments"] = self.comments as AnyObject?
-    result["notify_of_follower"] = self.follower as AnyObject?
-    result["notify_of_friend_activity"] = self.friendActivity as AnyObject?
-    result["notify_of_post_likes"] = self.postLikes as AnyObject?
-    result["notify_of_updates"] = self.updates as AnyObject?
-    result["notify_mobile_of_backings"] = self.mobileBackings as AnyObject?
-    result["notify_mobile_of_comments"] = self.mobileComments as AnyObject?
-    result["notify_mobile_of_follower"] = self.mobileFollower as AnyObject?
-    result["notify_mobile_of_friend_activity"] = self.mobileFriendActivity as AnyObject?
-    result["notify_mobile_of_post_likes"] = self.mobilePostLikes as AnyObject?
-    result["notify_mobile_of_updates"] = self.mobileUpdates as AnyObject?
+  public func encode() -> [String : Any] {
+    var result: [String: Any] = [:]
+    result["notify_of_backings"] = self.backings
+    result["notify_of_comments"] = self.comments
+    result["notify_of_follower"] = self.follower
+    result["notify_of_friend_activity"] = self.friendActivity
+    result["notify_of_post_likes"] = self.postLikes
+    result["notify_of_updates"] = self.updates
+    result["notify_mobile_of_backings"] = self.mobileBackings
+    result["notify_mobile_of_comments"] = self.mobileComments
+    result["notify_mobile_of_follower"] = self.mobileFollower
+    result["notify_mobile_of_friend_activity"] = self.mobileFriendActivity
+    result["notify_mobile_of_post_likes"] = self.mobilePostLikes
+    result["notify_mobile_of_updates"] = self.mobileUpdates
     return result
   }
 }
@@ -222,14 +223,14 @@ extension User.Stats: Decodable {
 }
 
 extension User.Stats: EncodableType {
-  public func encode() -> [String: AnyObject] {
-    var result: [String: AnyObject] = [:]
-    result["backed_projects_count"] =  self.backedProjectsCount as AnyObject?
-    result["created_projects_count"] = self.createdProjectsCount as AnyObject?
-    result["member_projects_count"] = self.memberProjectsCount as AnyObject?
-    result["starred_projects_count"] = self.starredProjectsCount as AnyObject?
-    result["unanswered_surveys_count"] = self.unansweredSurveysCount as AnyObject?
-    result["unread_messages_count"] =  self.unreadMessagesCount as AnyObject?
+  public func encode() -> [String: Any] {
+    var result: [String: Any] = [:]
+    result["backed_projects_count"] =  self.backedProjectsCount
+    result["created_projects_count"] = self.createdProjectsCount
+    result["member_projects_count"] = self.memberProjectsCount
+    result["starred_projects_count"] = self.starredProjectsCount
+    result["unanswered_surveys_count"] = self.unansweredSurveysCount
+    result["unread_messages_count"] =  self.unreadMessagesCount
     return result
   }
 }

--- a/KsApi/models/VoidEnvelope.swift
+++ b/KsApi/models/VoidEnvelope.swift
@@ -5,6 +5,6 @@ public struct VoidEnvelope {
 
 extension VoidEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<VoidEnvelope> {
-    return .Success(VoidEnvelope())
+    return .success(VoidEnvelope())
   }
 }

--- a/KsApi/models/VoidEnvelope.swift
+++ b/KsApi/models/VoidEnvelope.swift
@@ -4,7 +4,7 @@ public struct VoidEnvelope {
 }
 
 extension VoidEnvelope: Decodable {
-  public static func decode(json: JSON) -> Decoded<VoidEnvelope> {
+  public static func decode(_ json: JSON) -> Decoded<VoidEnvelope> {
     return .Success(VoidEnvelope())
   }
 }

--- a/KsApi/models/lenses/ActivityLenses.swift
+++ b/KsApi/models/lenses/ActivityLenses.swift
@@ -15,7 +15,7 @@ extension Activity {
         memberData: $1.memberData, project: $1.project, update: $1.update, user: $1.user) }
     )
 
-    public static let createdAt = Lens<Activity, NSTimeInterval>(
+    public static let createdAt = Lens<Activity, TimeInterval>(
       view: { $0.createdAt },
       set: { Activity(category: $1.category, comment: $1.comment, createdAt: $0, id: $1.id,
         memberData: $1.memberData, project: $1.project, update: $1.update, user: $1.user) }

--- a/KsApi/models/lenses/BackingLenses.swift
+++ b/KsApi/models/lenses/BackingLenses.swift
@@ -43,7 +43,7 @@ extension Backing {
         status: $1.status) }
     )
 
-    public static let pledgedAt = Lens<Backing, NSTimeInterval>(
+    public static let pledgedAt = Lens<Backing, TimeInterval>(
       view: { $0.pledgedAt },
       set: { Backing(amount: $1.amount, backer: $1.backer, backerId: $1.backerId, id: $1.id,
         locationId: $1.locationId, pledgedAt: $0, projectCountry: $1.projectCountry, projectId: $1.projectId,

--- a/KsApi/models/lenses/CommentLenses.swift
+++ b/KsApi/models/lenses/CommentLenses.swift
@@ -14,12 +14,12 @@ extension Comment {
         id: $1.id) }
     )
 
-    public static let createdAt = Lens<Comment, NSTimeInterval>(
+    public static let createdAt = Lens<Comment, TimeInterval>(
       view: { $0.createdAt },
       set: { Comment(author: $1.author, body: $1.body, createdAt: $0, deletedAt: $1.deletedAt, id: $1.id) }
     )
 
-    public static let deletedAt = Lens<Comment, NSTimeInterval?>(
+    public static let deletedAt = Lens<Comment, TimeInterval?>(
       view: { $0.deletedAt },
       set: { Comment(author: $1.author, body: $1.body, createdAt: $1.createdAt, deletedAt: $0, id: $1.id) }
     )

--- a/KsApi/models/lenses/Project.DatesLenses.swift
+++ b/KsApi/models/lenses/Project.DatesLenses.swift
@@ -3,31 +3,31 @@ import Prelude
 
 extension Project.Dates {
   public enum lens {
-    public static let deadline = Lens<Project.Dates, NSTimeInterval>(
+    public static let deadline = Lens<Project.Dates, TimeInterval>(
       view: { $0.deadline },
       set: { Project.Dates(deadline: $0, featuredAt: $1.featuredAt, launchedAt: $1.launchedAt,
         potdAt: $1.potdAt, stateChangedAt: $1.stateChangedAt) }
     )
 
-    public static let featuredAt = Lens<Project.Dates, NSTimeInterval?>(
+    public static let featuredAt = Lens<Project.Dates, TimeInterval?>(
       view: { $0.featuredAt },
       set: { Project.Dates(deadline: $1.deadline, featuredAt: $0, launchedAt: $1.launchedAt,
         potdAt: $1.potdAt, stateChangedAt: $1.stateChangedAt) }
     )
 
-    public static let launchedAt = Lens<Project.Dates, NSTimeInterval>(
+    public static let launchedAt = Lens<Project.Dates, TimeInterval>(
       view: { $0.launchedAt },
       set: { Project.Dates(deadline: $1.deadline, featuredAt: $1.featuredAt, launchedAt: $0,
         potdAt: $1.potdAt, stateChangedAt: $1.stateChangedAt) }
     )
 
-    public static let potdAt = Lens<Project.Dates, NSTimeInterval?>(
+    public static let potdAt = Lens<Project.Dates, TimeInterval?>(
       view: { $0.potdAt },
       set: { Project.Dates(deadline: $1.deadline, featuredAt: $1.featuredAt, launchedAt: $1.launchedAt,
         potdAt: $0, stateChangedAt: $1.stateChangedAt) }
     )
 
-    public static let stateChangedAt = Lens<Project.Dates, NSTimeInterval>(
+    public static let stateChangedAt = Lens<Project.Dates, TimeInterval>(
       view: { $0.stateChangedAt },
       set: { Project.Dates(deadline: $1.deadline, featuredAt: $1.featuredAt, launchedAt: $1.launchedAt,
         potdAt: $1.potdAt, stateChangedAt: $0) }

--- a/KsApi/models/lenses/Project.LiveStreamLenses.swift
+++ b/KsApi/models/lenses/Project.LiveStreamLenses.swift
@@ -18,7 +18,7 @@ extension Project.LiveStream {
       set: { .init(id: $1.id, isLiveNow: $1.isLiveNow, name: $0, startDate: $1.startDate, url: $1.url) }
     )
 
-    public static let startDate = Lens<Project.LiveStream, NSTimeInterval>(
+    public static let startDate = Lens<Project.LiveStream, TimeInterval>(
       view: { $0.startDate },
       set: { .init(id: $1.id, isLiveNow: $1.isLiveNow, name: $1.name, startDate: $0, url: $1.url) }
     )

--- a/KsApi/models/lenses/Project.MemberDataLenses.swift
+++ b/KsApi/models/lenses/Project.MemberDataLenses.swift
@@ -3,7 +3,7 @@ import Prelude
 
 extension Project.MemberData {
   public enum lens {
-    public static let lastUpdatePublishedAt = Lens<Project.MemberData, NSTimeInterval?>(
+    public static let lastUpdatePublishedAt = Lens<Project.MemberData, TimeInterval?>(
       view: { $0.lastUpdatePublishedAt },
       set: { Project.MemberData(lastUpdatePublishedAt: $0, permissions: $1.permissions,
         unreadMessagesCount: $1.unreadMessagesCount, unseenActivityCount: $1.unseenActivityCount) }

--- a/KsApi/models/lenses/ProjectLenses.swift
+++ b/KsApi/models/lenses/ProjectLenses.swift
@@ -233,7 +233,7 @@ extension LensType where Whole == Project, Part == Project.Stats {
 }
 
 extension LensType where Whole == Project, Part == Project.MemberData {
-  public var lastUpdatePublishedAt: Lens<Project, NSTimeInterval?> {
+  public var lastUpdatePublishedAt: Lens<Project, TimeInterval?> {
     return Project.lens.memberData • Project.MemberData.lens.lastUpdatePublishedAt
   }
 
@@ -247,23 +247,23 @@ extension LensType where Whole == Project, Part == Project.MemberData {
 }
 
 extension LensType where Whole == Project, Part == Project.Dates {
-  public var deadline: Lens<Project, NSTimeInterval> {
+  public var deadline: Lens<Project, TimeInterval> {
     return Project.lens.dates • Project.Dates.lens.deadline
   }
 
-  public var featuredAt: Lens<Project, NSTimeInterval?> {
+  public var featuredAt: Lens<Project, TimeInterval?> {
     return Project.lens.dates • Project.Dates.lens.featuredAt
   }
 
-  public var launchedAt: Lens<Project, NSTimeInterval> {
+  public var launchedAt: Lens<Project, TimeInterval> {
     return Project.lens.dates • Project.Dates.lens.launchedAt
   }
 
-  public var potdAt: Lens<Project, NSTimeInterval?> {
+  public var potdAt: Lens<Project, TimeInterval?> {
     return Project.lens.dates • Project.Dates.lens.potdAt
   }
 
-  public var stateChangedAt: Lens<Project, NSTimeInterval> {
+  public var stateChangedAt: Lens<Project, TimeInterval> {
     return Project.lens.dates • Project.Dates.lens.stateChangedAt
   }
 }

--- a/KsApi/models/lenses/ProjectStatsEnvelope.FundingDateStatsLenses.swift
+++ b/KsApi/models/lenses/ProjectStatsEnvelope.FundingDateStatsLenses.swift
@@ -21,7 +21,7 @@ extension ProjectStatsEnvelope.FundingDateStats {
         cumulativeBackersCount: $0, date: $1.date, pledged: $1.pledged) }
     )
 
-    public static let date = Lens<ProjectStatsEnvelope.FundingDateStats, NSTimeInterval>(
+    public static let date = Lens<ProjectStatsEnvelope.FundingDateStats, TimeInterval>(
       view: { $0.date },
       set: { .init(backersCount: $1.backersCount, cumulativePledged: $1.cumulativePledged,
         cumulativeBackersCount: $1.cumulativeBackersCount, date: $0, pledged: $1.pledged) }

--- a/KsApi/models/lenses/RewardLenses.swift
+++ b/KsApi/models/lenses/RewardLenses.swift
@@ -19,7 +19,7 @@ extension Reward {
         title: $1.title) }
     )
 
-    public static let endsAt = Lens<Reward, NSTimeInterval?>(
+    public static let endsAt = Lens<Reward, TimeInterval?>(
       view: { $0.endsAt },
       set: { Reward(backersCount: $1.backersCount, description: $1.description, endsAt: $0,
         estimatedDeliveryOn: $1.estimatedDeliveryOn, id: $1.id, limit: $1.limit, minimum: $1.minimum,
@@ -27,7 +27,7 @@ extension Reward {
         title: $1.title) }
     )
 
-    public static let estimatedDeliveryOn = Lens<Reward, NSTimeInterval?>(
+    public static let estimatedDeliveryOn = Lens<Reward, TimeInterval?>(
       view: { $0.estimatedDeliveryOn },
       set: { Reward(backersCount: $1.backersCount, description: $1.description, endsAt: $1.endsAt,
         estimatedDeliveryOn: $0, id: $1.id, limit: $1.limit, minimum: $1.minimum,
@@ -83,7 +83,7 @@ extension Reward {
         title: $1.title) }
     )
 
-    public static let startsAt = Lens<Reward, NSTimeInterval?>(
+    public static let startsAt = Lens<Reward, TimeInterval?>(
       view: { $0.startsAt },
       set: { Reward(backersCount: $1.backersCount, description: $1.description, endsAt: $1.endsAt,
         estimatedDeliveryOn: $1.estimatedDeliveryOn, id: $1.id, limit: $1.limit, minimum: $1.minimum,

--- a/KsApi/models/lenses/SurveyResponseLenses.swift
+++ b/KsApi/models/lenses/SurveyResponseLenses.swift
@@ -3,7 +3,7 @@ import Prelude
 
 extension SurveyResponse {
   public enum lens {
-    public static let answeredAt = Lens<SurveyResponse, NSTimeInterval?>(
+    public static let answeredAt = Lens<SurveyResponse, TimeInterval?>(
       view: { $0.answeredAt },
       set: { .init(answeredAt: $0, id: $1.id, project: $1.project, urls: $1.urls) }
     )

--- a/KsApi/models/lenses/UpdateLenses.swift
+++ b/KsApi/models/lenses/UpdateLenses.swift
@@ -43,7 +43,7 @@ extension Update {
         visible: $1.visible) }
     )
 
-    public static let publishedAt = Lens<Update, NSTimeInterval?>(
+    public static let publishedAt = Lens<Update, TimeInterval?>(
       view: { $0.publishedAt },
       set: { Update(body: $1.body, commentsCount: $1.commentsCount, hasLiked: $1.hasLiked, id: $1.id,
         isPublic: $1.isPublic, likesCount: $1.likesCount, projectId: $1.projectId,

--- a/KsApi/models/templates/ActivityTemplates.swift
+++ b/KsApi/models/templates/ActivityTemplates.swift
@@ -2,7 +2,7 @@ extension Activity {
   internal static let template = Activity(
     category: .launch,
     comment: nil,
-    createdAt: NSDate().timeIntervalSince1970,
+    createdAt: Date().timeIntervalSince1970,
     id: 1,
     memberData: Activity.MemberData(
       amount: nil,

--- a/KsApi/models/templates/BackingTemplates.swift
+++ b/KsApi/models/templates/BackingTemplates.swift
@@ -5,7 +5,7 @@ extension Backing {
     backerId: 1,
     id: 1,
     locationId: 1,
-    pledgedAt: NSDate().timeIntervalSince1970,
+    pledgedAt: Date().timeIntervalSince1970,
     projectCountry: "US",
     projectId: 1,
     reward: .template,

--- a/KsApi/models/templates/CommentTemplates.swift
+++ b/KsApi/models/templates/CommentTemplates.swift
@@ -2,7 +2,7 @@ extension Comment {
   internal static let template = Comment(
     author: .template,
     body: "Exciting!",
-    createdAt: NSDate().timeIntervalSince1970,
+    createdAt: Date().timeIntervalSince1970,
     deletedAt: nil,
     id: 1
   )

--- a/KsApi/models/templates/MessageTemplates.swift
+++ b/KsApi/models/templates/MessageTemplates.swift
@@ -6,7 +6,7 @@ extension Message {
       "accumsan nec aliquam a, porttitor sed dui. Integer iaculis ipsum fringilla metus " +
       "porttitor euismod. Donec in libero vitae lectus ultrices vehicula id eget dolor. " +
     "Nulla lacinia erat a ullamcorper sollicitudin.",
-    createdAt: NSDate().timeIntervalSince1970,
+    createdAt: Date().timeIntervalSince1970,
     id: 1,
     recipient: .template,
     sender: .template |> User.lens.id %~ { $0 + 1 }

--- a/KsApi/models/templates/ProjectTemplates.swift
+++ b/KsApi/models/templates/ProjectTemplates.swift
@@ -14,11 +14,11 @@ extension Project {
       unseenActivityCount: nil
     ),
     dates: Project.Dates(
-      deadline: NSDate().timeIntervalSince1970 + 60.0 * 60.0 * 24.0 * 15.0,
+      deadline: Date().timeIntervalSince1970 + 60.0 * 60.0 * 24.0 * 15.0,
       featuredAt: nil,
-      launchedAt: NSDate().timeIntervalSince1970 - 60.0 * 60.0 * 24.0 * 15.0,
+      launchedAt: Date().timeIntervalSince1970 - 60.0 * 60.0 * 24.0 * 15.0,
       potdAt: nil,
-      stateChangedAt: NSDate().timeIntervalSince1970 - 60.0 * 60.0 * 24.0 * 15.0
+      stateChangedAt: Date().timeIntervalSince1970 - 60.0 * 60.0 * 24.0 * 15.0
     ),
     id: 1,
     location: .template,

--- a/KsApi/models/templates/RewardTemplates.swift
+++ b/KsApi/models/templates/RewardTemplates.swift
@@ -5,7 +5,7 @@ extension Reward {
     backersCount: 50,
     description: "A cool thing",
     endsAt: nil,
-    estimatedDeliveryOn: NSDate().timeIntervalSince1970 + 60.0 * 60.0 * 24.0 * 365.0,
+    estimatedDeliveryOn: Date().timeIntervalSince1970 + 60.0 * 60.0 * 24.0 * 365.0,
     id: 1,
     limit: 100,
     minimum: 10,

--- a/KsApi/models/templates/UpdateTemplates.swift
+++ b/KsApi/models/templates/UpdateTemplates.swift
@@ -8,7 +8,7 @@ extension Update {
     isPublic: true,
     likesCount: 3,
     projectId: 1,
-    publishedAt: NSDate().timeIntervalSince1970,
+    publishedAt: Date().timeIntervalSince1970,
     sequence: 1,
     title: "Hello",
     urls: Update.UrlsEnvelope(web: Update.UrlsEnvelope.WebEnvelope(

--- a/KsApiTests/ServiceTypeTests.swift
+++ b/KsApiTests/ServiceTypeTests.swift
@@ -2,11 +2,11 @@ import XCTest
 @testable import KsApi
 
 final class ServiceTypeTests: XCTestCase {
-  private let service = Service(
+  fileprivate let service = Service(
     appId: "com.kickstarter.test",
     serverConfig: ServerConfig(
-      apiBaseUrl: NSURL(string: "http://api.ksr.com")!,
-      webBaseUrl: NSURL(string: "http://www.ksr.com")!,
+      apiBaseUrl: URL(string: "http://api.ksr.com")!,
+      webBaseUrl: URL(string: "http://www.ksr.com")!,
       apiClientAuth: ClientAuth(
         clientId: "deadbeef"
       ),
@@ -22,11 +22,11 @@ final class ServiceTypeTests: XCTestCase {
     buildVersion: "1234567890"
   )
 
-  private let anonAdHocService = Service(
+  fileprivate let anonAdHocService = Service(
     appId: "com.kickstarter.test",
     serverConfig: ServerConfig(
-      apiBaseUrl: NSURL(string: "http://api-hq.dev.ksr.com")!,
-      webBaseUrl: NSURL(string: "http://hq.dev.ksr.com")!,
+      apiBaseUrl: URL(string: "http://api-hq.dev.ksr.com")!,
+      webBaseUrl: URL(string: "http://hq.dev.ksr.com")!,
       apiClientAuth: ClientAuth(
         clientId: "deadbeef"
       ),
@@ -37,11 +37,11 @@ final class ServiceTypeTests: XCTestCase {
     )
   )
 
-  private let anonService = Service(
+  fileprivate let anonService = Service(
     appId: "com.kickstarter.test",
     serverConfig: ServerConfig(
-      apiBaseUrl: NSURL(string: "http://api.ksr.com")!,
-      webBaseUrl: NSURL(string: "http://hq.ksr.com")!,
+      apiBaseUrl: URL(string: "http://api.ksr.com")!,
+      webBaseUrl: URL(string: "http://hq.ksr.com")!,
       apiClientAuth: ClientAuth(
         clientId: "deadbeef"
       ),
@@ -54,8 +54,8 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testIsPreparedAdhocWithoutOauthToken() {
-    let URL = NSURL(string: "http://api-dev.ksr.com/v1/test?key=value") ?? NSURL()
-    let request = NSURLRequest(URL: URL)
+    let URL = Foundation.URL(string: "http://api-dev.ksr.com/v1/test?key=value") ?? Foundation.URL()
+    let request = URLRequest(url: URL)
     XCTAssertFalse(self.anonAdHocService.isPrepared(request: request))
     XCTAssertTrue(self.anonAdHocService.isPrepared(request:
       self.anonAdHocService.preparedRequest(forRequest: request))
@@ -63,21 +63,21 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testIsPreparedWithOauthToken() {
-    let URL = NSURL(string: "http://api.ksr.com/v1/test?key=value&oauth_token=cafebeef") ?? NSURL()
-    let request = NSURLRequest(URL: URL)
+    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value&oauth_token=cafebeef") ?? Foundation.URL()
+    let request = URLRequest(url: URL)
     XCTAssertFalse(self.service.isPrepared(request: request))
     XCTAssertTrue(self.service.isPrepared(request: self.service.preparedRequest(forRequest: request)))
   }
 
   func testIsPreparedWithoutOauthToken() {
-    let URL = NSURL(string: "http://api.ksr.com/v1/test?key=value") ?? NSURL()
-    let request = NSURLRequest(URL: URL)
+    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? Foundation.URL()
+    let request = URLRequest(url: URL)
     XCTAssertFalse(self.anonService.isPrepared(request: request))
     XCTAssertTrue(self.anonService.isPrepared(request: self.anonService.preparedRequest(forRequest: request)))
   }
 
   func testPreparedRequest() {
-    let URL = NSURL(string: "http://api.ksr.com/v1/test?key=value") ?? NSURL()
+    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? Foundation.URL()
     let request = self.service.preparedRequest(forRequest: .init(URL: URL))
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&key=value&oauth_token=cafebeef",
@@ -91,7 +91,7 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testPreparedURL() {
-    let URL = NSURL(string: "http://api.ksr.com/v1/test?key=value") ?? NSURL()
+    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? Foundation.URL()
     let request = self.service.preparedRequest(forURL: URL, query: ["extra": "1"])
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&extra=1&key=value&oauth_token=cafebeef",
@@ -106,7 +106,7 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testPreparedDeleteURL() {
-    let URL = NSURL(string: "http://api.ksr.com/v1/test?key=value") ?? NSURL()
+    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? Foundation.URL()
     let request = self.service.preparedRequest(forURL: URL, method: .DELETE, query: ["extra": "1"])
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&extra=1&key=value&oauth_token=cafebeef",
@@ -121,7 +121,7 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testPreparedPostURL() {
-    let URL = NSURL(string: "http://api.ksr.com/v1/test?key=value") ?? NSURL()
+    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? Foundation.URL()
     let request = self.service.preparedRequest(forURL: URL, method: .POST, query: ["extra": "1"])
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&key=value&oauth_token=cafebeef",
@@ -135,15 +135,15 @@ final class ServiceTypeTests: XCTestCase {
     )
     XCTAssertEqual("POST", request.HTTPMethod)
     XCTAssertEqual("{\"extra\":\"1\"}",
-                   String(data: request.HTTPBody ?? NSData(), encoding: NSUTF8StringEncoding))
+                   String(data: request.HTTPBody ?? Data(), encoding: String.Encoding.utf8))
   }
 
   func testPreparedPostURLWithBody() {
-    let URL = NSURL(string: "http://api.ksr.com/v1/test?key=value") ?? NSURL()
-    let baseRequest = NSMutableURLRequest(URL: URL)
-    let body = "test".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
-    baseRequest.HTTPBody = body
-    baseRequest.HTTPMethod = "POST"
+    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? Foundation.URL()
+    let baseRequest = NSMutableURLRequest(url: URL)
+    let body = "test".data(using: String.Encoding.utf8, allowLossyConversion: false)
+    baseRequest.httpBody = body
+    baseRequest.httpMethod = "POST"
     let request = self.service.preparedRequest(forRequest: baseRequest, query: ["extra": "1"])
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&key=value&oauth_token=cafebeef",
@@ -159,7 +159,7 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testPreparedAdHocWithoutOauthToken() {
-    let URL = NSURL(string: "http://api-hq.ksr.com/v1/test?key=value") ?? NSURL()
+    let URL = Foundation.URL(string: "http://api-hq.ksr.com/v1/test?key=value") ?? Foundation.URL()
     let request = anonAdHocService.preparedRequest(forRequest: .init(URL: URL))
 
     XCTAssertEqual("http://api-hq.ksr.com/v1/test?client_id=deadbeef&key=value", request.URL?.absoluteString)
@@ -175,8 +175,8 @@ final class ServiceTypeTests: XCTestCase {
     let anonService = Service(
       appId: "com.kickstarter.test",
       serverConfig: ServerConfig(
-        apiBaseUrl: NSURL(string: "http://api.ksr.com")!,
-        webBaseUrl: NSURL(string: "http://www.ksr.com")!,
+        apiBaseUrl: Foundation.URL(string: "http://api.ksr.com")!,
+        webBaseUrl: Foundation.URL(string: "http://www.ksr.com")!,
         apiClientAuth: ClientAuth(
           clientId: "deadbeef"
         ),
@@ -187,7 +187,7 @@ final class ServiceTypeTests: XCTestCase {
       )
     )
 
-    let URL = NSURL(string: "http://api.ksr.com/v1/test?key=value") ?? NSURL()
+    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? Foundation.URL()
     let request = anonService.preparedRequest(forRequest: .init(URL: URL))
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&key=value",

--- a/KsApiTests/ServiceTypeTests.swift
+++ b/KsApiTests/ServiceTypeTests.swift
@@ -87,7 +87,7 @@ final class ServiceTypeTests: XCTestCase {
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1234567890", "Authorization": "token cafebeef", "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
-        "User-Agent": "Kickstarter/1 (iPhone; iOS \(UIDevice.current.systemVersion) Scale/2.0)"],
+        "User-Agent": userAgent()],
       request.allHTTPHeaderFields!
     )
   }
@@ -101,7 +101,7 @@ final class ServiceTypeTests: XCTestCase {
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1234567890", "Authorization": "token cafebeef", "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
-        "User-Agent": "Kickstarter/1 (iPhone; iOS \(UIDevice.current.systemVersion) Scale/2.0)"],
+        "User-Agent": userAgent()],
       request.allHTTPHeaderFields!
     )
     XCTAssertEqual("GET", request.httpMethod)
@@ -116,7 +116,7 @@ final class ServiceTypeTests: XCTestCase {
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1234567890", "Authorization": "token cafebeef", "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
-        "User-Agent": "Kickstarter/1 (iPhone; iOS \(UIDevice.current.systemVersion) Scale/2.0)"],
+        "User-Agent": userAgent()],
       request.allHTTPHeaderFields!
     )
     XCTAssertEqual("DELETE", request.httpMethod)
@@ -132,7 +132,7 @@ final class ServiceTypeTests: XCTestCase {
       ["Kickstarter-iOS-App": "1234567890", "Authorization": "token cafebeef", "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
         "Content-Type": "application/json; charset=utf-8",
-        "User-Agent": "Kickstarter/1 (iPhone; iOS \(UIDevice.current.systemVersion) Scale/2.0)"],
+        "User-Agent": userAgent()],
       request.allHTTPHeaderFields!
     )
     XCTAssertEqual("POST", request.httpMethod)
@@ -153,7 +153,7 @@ final class ServiceTypeTests: XCTestCase {
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1234567890", "Authorization": "token cafebeef", "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
-        "User-Agent": "Kickstarter/1 (iPhone; iOS \(UIDevice.current.systemVersion) Scale/2.0)"],
+        "User-Agent": userAgent()],
       request.allHTTPHeaderFields!
     )
     XCTAssertEqual("POST", request.httpMethod)
@@ -168,7 +168,7 @@ final class ServiceTypeTests: XCTestCase {
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1", "Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
         "Accept-Language": "en", "Kickstarter-App-Id": "com.kickstarter.test",
-        "User-Agent": "Kickstarter/1 (iPhone; iOS \(UIDevice.current.systemVersion) Scale/2.0)"],
+        "User-Agent": userAgent()],
       request.allHTTPHeaderFields!
     )
   }
@@ -197,8 +197,13 @@ final class ServiceTypeTests: XCTestCase {
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1", "Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
         "Accept-Language": "en", "Kickstarter-App-Id": "com.kickstarter.test",
-        "User-Agent": "Kickstarter/1 (iPhone; iOS \(UIDevice.current.systemVersion) Scale/2.0)"],
+        "User-Agent": userAgent()],
       request.allHTTPHeaderFields!
     )
   }
+}
+
+private func userAgent() -> String {
+  return "Kickstarter/1 (\(UIDevice.current.model); iOS \(UIDevice.current.systemVersion) "
+    + "Scale/\(UIScreen.main.scale))"
 }

--- a/KsApiTests/ServiceTypeTests.swift
+++ b/KsApiTests/ServiceTypeTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 @testable import KsApi
 
+private let emptyUrl = URL(string: "")!
+
 final class ServiceTypeTests: XCTestCase {
   fileprivate let service = Service(
     appId: "com.kickstarter.test",
@@ -54,7 +56,7 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testIsPreparedAdhocWithoutOauthToken() {
-    let URL = Foundation.URL(string: "http://api-dev.ksr.com/v1/test?key=value") ?? Foundation.URL()
+    let URL = Foundation.URL(string: "http://api-dev.ksr.com/v1/test?key=value") ?? emptyUrl
     let request = URLRequest(url: URL)
     XCTAssertFalse(self.anonAdHocService.isPrepared(request: request))
     XCTAssertTrue(self.anonAdHocService.isPrepared(request:
@@ -63,25 +65,27 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testIsPreparedWithOauthToken() {
-    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value&oauth_token=cafebeef") ?? Foundation.URL()
+    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value&oauth_token=cafebeef") ?? emptyUrl
     let request = URLRequest(url: URL)
     XCTAssertFalse(self.service.isPrepared(request: request))
     XCTAssertTrue(self.service.isPrepared(request: self.service.preparedRequest(forRequest: request)))
   }
 
   func testIsPreparedWithoutOauthToken() {
-    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? Foundation.URL()
+    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? emptyUrl
     let request = URLRequest(url: URL)
     XCTAssertFalse(self.anonService.isPrepared(request: request))
     XCTAssertTrue(self.anonService.isPrepared(request: self.anonService.preparedRequest(forRequest: request)))
   }
 
   func testPreparedRequest() {
-    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? Foundation.URL()
-    let request = self.service.preparedRequest(forRequest: .init(URL: URL))
+    let url = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? emptyUrl
+    let request = self.service.preparedRequest(forRequest: .init(url: url))
+
+
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&key=value&oauth_token=cafebeef",
-                   request.URL?.absoluteString)
+                   request.url?.absoluteString)
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1234567890", "Authorization": "token cafebeef", "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
@@ -91,41 +95,41 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testPreparedURL() {
-    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? Foundation.URL()
+    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? emptyUrl
     let request = self.service.preparedRequest(forURL: URL, query: ["extra": "1"])
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&extra=1&key=value&oauth_token=cafebeef",
-                   request.URL?.absoluteString)
+                   request.url?.absoluteString)
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1234567890", "Authorization": "token cafebeef", "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
         "User-Agent": "Kickstarter/1 (iPhone; iOS 9.3 Scale/2.0)"],
       request.allHTTPHeaderFields!
     )
-    XCTAssertEqual("GET", request.HTTPMethod)
+    XCTAssertEqual("GET", request.httpMethod)
   }
 
   func testPreparedDeleteURL() {
-    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? Foundation.URL()
+    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? emptyUrl
     let request = self.service.preparedRequest(forURL: URL, method: .DELETE, query: ["extra": "1"])
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&extra=1&key=value&oauth_token=cafebeef",
-                   request.URL?.absoluteString)
+                   request.url?.absoluteString)
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1234567890", "Authorization": "token cafebeef", "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
         "User-Agent": "Kickstarter/1 (iPhone; iOS 9.3 Scale/2.0)"],
       request.allHTTPHeaderFields!
     )
-    XCTAssertEqual("DELETE", request.HTTPMethod)
+    XCTAssertEqual("DELETE", request.httpMethod)
   }
 
   func testPreparedPostURL() {
-    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? Foundation.URL()
+    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? emptyUrl
     let request = self.service.preparedRequest(forURL: URL, method: .POST, query: ["extra": "1"])
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&key=value&oauth_token=cafebeef",
-                   request.URL?.absoluteString)
+                   request.url?.absoluteString)
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1234567890", "Authorization": "token cafebeef", "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
@@ -133,36 +137,36 @@ final class ServiceTypeTests: XCTestCase {
         "User-Agent": "Kickstarter/1 (iPhone; iOS 9.3 Scale/2.0)"],
       request.allHTTPHeaderFields!
     )
-    XCTAssertEqual("POST", request.HTTPMethod)
+    XCTAssertEqual("POST", request.httpMethod)
     XCTAssertEqual("{\"extra\":\"1\"}",
-                   String(data: request.HTTPBody ?? Data(), encoding: String.Encoding.utf8))
+                   String(data: request.httpBody ?? Data(), encoding: .utf8))
   }
 
   func testPreparedPostURLWithBody() {
-    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? Foundation.URL()
-    let baseRequest = NSMutableURLRequest(url: URL)
+    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? emptyUrl
+    var baseRequest = URLRequest(url: URL)
     let body = "test".data(using: String.Encoding.utf8, allowLossyConversion: false)
     baseRequest.httpBody = body
     baseRequest.httpMethod = "POST"
     let request = self.service.preparedRequest(forRequest: baseRequest, query: ["extra": "1"])
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&key=value&oauth_token=cafebeef",
-                   request.URL?.absoluteString)
+                   request.url?.absoluteString)
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1234567890", "Authorization": "token cafebeef", "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
         "User-Agent": "Kickstarter/1 (iPhone; iOS 9.3 Scale/2.0)"],
       request.allHTTPHeaderFields!
     )
-    XCTAssertEqual("POST", request.HTTPMethod)
-    XCTAssertEqual(body, request.HTTPBody, "Body remains unchanged")
+    XCTAssertEqual("POST", request.httpMethod)
+    XCTAssertEqual(body, request.httpBody, "Body remains unchanged")
   }
 
   func testPreparedAdHocWithoutOauthToken() {
-    let URL = Foundation.URL(string: "http://api-hq.ksr.com/v1/test?key=value") ?? Foundation.URL()
-    let request = anonAdHocService.preparedRequest(forRequest: .init(URL: URL))
+    let URL = Foundation.URL(string: "http://api-hq.ksr.com/v1/test?key=value") ?? emptyUrl
+    let request = anonAdHocService.preparedRequest(forRequest: .init(url: URL))
 
-    XCTAssertEqual("http://api-hq.ksr.com/v1/test?client_id=deadbeef&key=value", request.URL?.absoluteString)
+    XCTAssertEqual("http://api-hq.ksr.com/v1/test?client_id=deadbeef&key=value", request.url?.absoluteString)
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1", "Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
         "Accept-Language": "en", "Kickstarter-App-Id": "com.kickstarter.test",
@@ -187,11 +191,11 @@ final class ServiceTypeTests: XCTestCase {
       )
     )
 
-    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? Foundation.URL()
-    let request = anonService.preparedRequest(forRequest: .init(URL: URL))
+    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? emptyUrl
+    let request = anonService.preparedRequest(forRequest: .init(url: URL))
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&key=value",
-                   request.URL?.absoluteString)
+                   request.url?.absoluteString)
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1", "Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
         "Accept-Language": "en", "Kickstarter-App-Id": "com.kickstarter.test",

--- a/KsApiTests/ServiceTypeTests.swift
+++ b/KsApiTests/ServiceTypeTests.swift
@@ -87,7 +87,7 @@ final class ServiceTypeTests: XCTestCase {
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1234567890", "Authorization": "token cafebeef", "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
-        "User-Agent": "Kickstarter/1 (iPhone; iOS 9.3 Scale/2.0)"],
+        "User-Agent": "Kickstarter/1 (iPhone; iOS \(UIDevice.current.systemVersion) Scale/2.0)"],
       request.allHTTPHeaderFields!
     )
   }
@@ -101,7 +101,7 @@ final class ServiceTypeTests: XCTestCase {
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1234567890", "Authorization": "token cafebeef", "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
-        "User-Agent": "Kickstarter/1 (iPhone; iOS 9.3 Scale/2.0)"],
+        "User-Agent": "Kickstarter/1 (iPhone; iOS \(UIDevice.current.systemVersion) Scale/2.0)"],
       request.allHTTPHeaderFields!
     )
     XCTAssertEqual("GET", request.httpMethod)
@@ -116,7 +116,7 @@ final class ServiceTypeTests: XCTestCase {
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1234567890", "Authorization": "token cafebeef", "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
-        "User-Agent": "Kickstarter/1 (iPhone; iOS 9.3 Scale/2.0)"],
+        "User-Agent": "Kickstarter/1 (iPhone; iOS \(UIDevice.current.systemVersion) Scale/2.0)"],
       request.allHTTPHeaderFields!
     )
     XCTAssertEqual("DELETE", request.httpMethod)
@@ -132,7 +132,7 @@ final class ServiceTypeTests: XCTestCase {
       ["Kickstarter-iOS-App": "1234567890", "Authorization": "token cafebeef", "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
         "Content-Type": "application/json; charset=utf-8",
-        "User-Agent": "Kickstarter/1 (iPhone; iOS 9.3 Scale/2.0)"],
+        "User-Agent": "Kickstarter/1 (iPhone; iOS \(UIDevice.current.systemVersion) Scale/2.0)"],
       request.allHTTPHeaderFields!
     )
     XCTAssertEqual("POST", request.httpMethod)
@@ -153,7 +153,7 @@ final class ServiceTypeTests: XCTestCase {
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1234567890", "Authorization": "token cafebeef", "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
-        "User-Agent": "Kickstarter/1 (iPhone; iOS 9.3 Scale/2.0)"],
+        "User-Agent": "Kickstarter/1 (iPhone; iOS \(UIDevice.current.systemVersion) Scale/2.0)"],
       request.allHTTPHeaderFields!
     )
     XCTAssertEqual("POST", request.httpMethod)
@@ -168,7 +168,7 @@ final class ServiceTypeTests: XCTestCase {
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1", "Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
         "Accept-Language": "en", "Kickstarter-App-Id": "com.kickstarter.test",
-        "User-Agent": "Kickstarter/1 (iPhone; iOS 9.3 Scale/2.0)"],
+        "User-Agent": "Kickstarter/1 (iPhone; iOS \(UIDevice.current.systemVersion) Scale/2.0)"],
       request.allHTTPHeaderFields!
     )
   }
@@ -197,7 +197,7 @@ final class ServiceTypeTests: XCTestCase {
     XCTAssertEqual(
       ["Kickstarter-iOS-App": "1", "Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
         "Accept-Language": "en", "Kickstarter-App-Id": "com.kickstarter.test",
-        "User-Agent": "Kickstarter/1 (iPhone; iOS 9.3 Scale/2.0)"],
+        "User-Agent": "Kickstarter/1 (iPhone; iOS \(UIDevice.current.systemVersion) Scale/2.0)"],
       request.allHTTPHeaderFields!
     )
   }

--- a/KsApiTests/ServiceTypeTests.swift
+++ b/KsApiTests/ServiceTypeTests.swift
@@ -1,10 +1,8 @@
 import XCTest
 @testable import KsApi
 
-private let emptyUrl = URL(string: "")!
-
 final class ServiceTypeTests: XCTestCase {
-  fileprivate let service = Service(
+  private let service = Service(
     appId: "com.kickstarter.test",
     serverConfig: ServerConfig(
       apiBaseUrl: URL(string: "http://api.ksr.com")!,
@@ -24,7 +22,7 @@ final class ServiceTypeTests: XCTestCase {
     buildVersion: "1234567890"
   )
 
-  fileprivate let anonAdHocService = Service(
+  private let anonAdHocService = Service(
     appId: "com.kickstarter.test",
     serverConfig: ServerConfig(
       apiBaseUrl: URL(string: "http://api-hq.dev.ksr.com")!,
@@ -39,7 +37,7 @@ final class ServiceTypeTests: XCTestCase {
     )
   )
 
-  fileprivate let anonService = Service(
+  private let anonService = Service(
     appId: "com.kickstarter.test",
     serverConfig: ServerConfig(
       apiBaseUrl: URL(string: "http://api.ksr.com")!,
@@ -56,8 +54,8 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testIsPreparedAdhocWithoutOauthToken() {
-    let URL = Foundation.URL(string: "http://api-dev.ksr.com/v1/test?key=value") ?? emptyUrl
-    let request = URLRequest(url: URL)
+    let url = URL(string: "http://api-dev.ksr.com/v1/test?key=value")!
+    let request = URLRequest(url: url)
     XCTAssertFalse(self.anonAdHocService.isPrepared(request: request))
     XCTAssertTrue(self.anonAdHocService.isPrepared(request:
       self.anonAdHocService.preparedRequest(forRequest: request))
@@ -65,21 +63,21 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testIsPreparedWithOauthToken() {
-    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value&oauth_token=cafebeef") ?? emptyUrl
-    let request = URLRequest(url: URL)
+    let url = URL(string: "http://api.ksr.com/v1/test?key=value&oauth_token=cafebeef")!
+    let request = URLRequest(url: url)
     XCTAssertFalse(self.service.isPrepared(request: request))
     XCTAssertTrue(self.service.isPrepared(request: self.service.preparedRequest(forRequest: request)))
   }
 
   func testIsPreparedWithoutOauthToken() {
-    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? emptyUrl
-    let request = URLRequest(url: URL)
+    let url = URL(string: "http://api.ksr.com/v1/test?key=value")!
+    let request = URLRequest(url: url)
     XCTAssertFalse(self.anonService.isPrepared(request: request))
     XCTAssertTrue(self.anonService.isPrepared(request: self.anonService.preparedRequest(forRequest: request)))
   }
 
   func testPreparedRequest() {
-    let url = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? emptyUrl
+    let url = URL(string: "http://api.ksr.com/v1/test?key=value")!
     let request = self.service.preparedRequest(forRequest: .init(url: url))
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&key=value&oauth_token=cafebeef",
@@ -93,8 +91,8 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testPreparedURL() {
-    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? emptyUrl
-    let request = self.service.preparedRequest(forURL: URL, query: ["extra": "1"])
+    let url = URL(string: "http://api.ksr.com/v1/test?key=value")!
+    let request = self.service.preparedRequest(forURL: url, query: ["extra": "1"])
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&extra=1&key=value&oauth_token=cafebeef",
                    request.url?.absoluteString)
@@ -108,8 +106,8 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testPreparedDeleteURL() {
-    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? emptyUrl
-    let request = self.service.preparedRequest(forURL: URL, method: .DELETE, query: ["extra": "1"])
+    let url = URL(string: "http://api.ksr.com/v1/test?key=value")!
+    let request = self.service.preparedRequest(forURL: url, method: .DELETE, query: ["extra": "1"])
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&extra=1&key=value&oauth_token=cafebeef",
                    request.url?.absoluteString)
@@ -123,8 +121,8 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testPreparedPostURL() {
-    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? emptyUrl
-    let request = self.service.preparedRequest(forURL: URL, method: .POST, query: ["extra": "1"])
+    let url = URL(string: "http://api.ksr.com/v1/test?key=value")!
+    let request = self.service.preparedRequest(forURL: url, method: .POST, query: ["extra": "1"])
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&key=value&oauth_token=cafebeef",
                    request.url?.absoluteString)
@@ -141,8 +139,8 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testPreparedPostURLWithBody() {
-    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? emptyUrl
-    var baseRequest = URLRequest(url: URL)
+    let url = URL(string: "http://api.ksr.com/v1/test?key=value")!
+    var baseRequest = URLRequest(url: url)
     let body = "test".data(using: String.Encoding.utf8, allowLossyConversion: false)
     baseRequest.httpBody = body
     baseRequest.httpMethod = "POST"
@@ -161,8 +159,8 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testPreparedAdHocWithoutOauthToken() {
-    let URL = Foundation.URL(string: "http://api-hq.ksr.com/v1/test?key=value") ?? emptyUrl
-    let request = anonAdHocService.preparedRequest(forRequest: .init(url: URL))
+    let url = URL(string: "http://api-hq.ksr.com/v1/test?key=value")!
+    let request = anonAdHocService.preparedRequest(forRequest: .init(url: url))
 
     XCTAssertEqual("http://api-hq.ksr.com/v1/test?client_id=deadbeef&key=value", request.url?.absoluteString)
     XCTAssertEqual(
@@ -177,8 +175,8 @@ final class ServiceTypeTests: XCTestCase {
     let anonService = Service(
       appId: "com.kickstarter.test",
       serverConfig: ServerConfig(
-        apiBaseUrl: Foundation.URL(string: "http://api.ksr.com")!,
-        webBaseUrl: Foundation.URL(string: "http://www.ksr.com")!,
+        apiBaseUrl: URL(string: "http://api.ksr.com")!,
+        webBaseUrl: URL(string: "http://www.ksr.com")!,
         apiClientAuth: ClientAuth(
           clientId: "deadbeef"
         ),
@@ -189,8 +187,8 @@ final class ServiceTypeTests: XCTestCase {
       )
     )
 
-    let URL = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? emptyUrl
-    let request = anonService.preparedRequest(forRequest: .init(url: URL))
+    let url = URL(string: "http://api.ksr.com/v1/test?key=value")!
+    let request = anonService.preparedRequest(forRequest: .init(url: url))
 
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&key=value",
                    request.url?.absoluteString)

--- a/KsApiTests/ServiceTypeTests.swift
+++ b/KsApiTests/ServiceTypeTests.swift
@@ -82,8 +82,6 @@ final class ServiceTypeTests: XCTestCase {
     let url = Foundation.URL(string: "http://api.ksr.com/v1/test?key=value") ?? emptyUrl
     let request = self.service.preparedRequest(forRequest: .init(url: url))
 
-
-
     XCTAssertEqual("http://api.ksr.com/v1/test?client_id=deadbeef&key=value&oauth_token=cafebeef",
                    request.url?.absoluteString)
     XCTAssertEqual(

--- a/KsApiTests/ServiceTypeTests.swift
+++ b/KsApiTests/ServiceTypeTests.swift
@@ -141,7 +141,7 @@ final class ServiceTypeTests: XCTestCase {
   func testPreparedPostURLWithBody() {
     let url = URL(string: "http://api.ksr.com/v1/test?key=value")!
     var baseRequest = URLRequest(url: url)
-    let body = "test".data(using: String.Encoding.utf8, allowLossyConversion: false)
+    let body = "test".data(using: .utf8, allowLossyConversion: false)
     baseRequest.httpBody = body
     baseRequest.httpMethod = "POST"
     let request = self.service.preparedRequest(forRequest: baseRequest, query: ["extra": "1"])

--- a/KsApiTests/lib/EncodableTests.swift
+++ b/KsApiTests/lib/EncodableTests.swift
@@ -7,7 +7,7 @@ final class EncodableTests: XCTestCase {
     let id: Int
     let name: String
     func encode() -> [String:AnyObject] {
-      return ["ID": self.id, "NAME": self.name]
+      return ["ID": self.id as AnyObject, "NAME": self.name as AnyObject]
     }
   }
 
@@ -19,7 +19,7 @@ final class EncodableTests: XCTestCase {
   func testToJSONData() {
     let model = EncodableModel(id: 1, name: "Blob")
     let jsonString = "{\"ID\":1,\"NAME\":\"Blob\"}"
-    let jsonData = jsonString.dataUsingEncoding(NSUTF8StringEncoding)
+    let jsonData = jsonString.data(using: String.Encoding.utf8)
 
     XCTAssertEqual(model.toJSONData(), jsonData)
   }

--- a/KsApiTests/lib/EncodableTests.swift
+++ b/KsApiTests/lib/EncodableTests.swift
@@ -6,8 +6,11 @@ final class EncodableTests: XCTestCase {
   struct EncodableModel: EncodableType {
     let id: Int
     let name: String
-    func encode() -> [String:AnyObject] {
-      return ["ID": self.id as AnyObject, "NAME": self.name as AnyObject]
+    func encode() -> [String:Any] {
+      return [
+        "ID": self.id,
+        "NAME": self.name
+      ]
     }
   }
 

--- a/KsApiTests/lib/EncodableTests.swift
+++ b/KsApiTests/lib/EncodableTests.swift
@@ -22,7 +22,7 @@ final class EncodableTests: XCTestCase {
   func testToJSONData() {
     let model = EncodableModel(id: 1, name: "Blob")
     let jsonString = "{\"ID\":1,\"NAME\":\"Blob\"}"
-    let jsonData = jsonString.data(using: String.Encoding.utf8)
+    let jsonData = jsonString.data(using: .utf8)
 
     XCTAssertEqual(model.toJSONData(), jsonData)
   }

--- a/KsApiTests/models/ActivityTests.swift
+++ b/KsApiTests/models/ActivityTests.swift
@@ -87,6 +87,6 @@ final internal class ActivityTests: XCTestCase {
       ])
 
     XCTAssertNil(activity.error)
-    XCTAssertEqual(.Some(.unknown), activity.value?.category)
+    XCTAssertEqual(.some(.unknown), activity.value?.category)
   }
 }

--- a/KsApiTests/models/CategoryTests.swift
+++ b/KsApiTests/models/CategoryTests.swift
@@ -39,7 +39,7 @@ class CategoryTests: XCTestCase {
       Category.documentary,
       ]
 
-    XCTAssertEqual(sorted, categories.sort())
+    XCTAssertEqual(sorted, categories.sorted())
   }
 
   func testDescription() {

--- a/KsApiTests/models/ChangePaymentMethodEnvelopeTests.swift
+++ b/KsApiTests/models/ChangePaymentMethodEnvelopeTests.swift
@@ -4,13 +4,13 @@ import XCTest
 final class ChangePaymentMethodEnvelopeTests: XCTestCase {
 
   func testDecodingWithStringStatus() {
-    let decoded = ChangePaymentMethodEnvelope.decodeJSONDictionary(["status" : "200"])
+    let decoded = ChangePaymentMethodEnvelope.decodeJSONDictionary(["status": "200"])
     XCTAssertNil(decoded.error)
     XCTAssertEqual(200, decoded.value?.status)
   }
 
   func testDecodingWithIntStatus() {
-    let decoded = ChangePaymentMethodEnvelope.decodeJSONDictionary(["status" : 200])
+    let decoded = ChangePaymentMethodEnvelope.decodeJSONDictionary(["status": 200])
     XCTAssertNil(decoded.error)
     XCTAssertEqual(200, decoded.value?.status)
   }
@@ -21,7 +21,7 @@ final class ChangePaymentMethodEnvelopeTests: XCTestCase {
   }
 
   func testDecodingWithBadStatusData() {
-    let decoded = ChangePaymentMethodEnvelope.decodeJSONDictionary(["status" : "bad data"])
+    let decoded = ChangePaymentMethodEnvelope.decodeJSONDictionary(["status": "bad data"])
     XCTAssertNil(decoded.error)
     XCTAssertEqual(0, decoded.value?.status)
   }

--- a/KsApiTests/models/CheckoutEnvelopeTests.swift
+++ b/KsApiTests/models/CheckoutEnvelopeTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class CheckoutEnvelopeTests: XCTestCase {
   func testJsonDecoding() {
-    let json: [String: Any] = [
+    let json: [String:Any] = [
       "state": "failed",
       "state_reason": "Oof!"
     ]

--- a/KsApiTests/models/CheckoutEnvelopeTests.swift
+++ b/KsApiTests/models/CheckoutEnvelopeTests.swift
@@ -5,8 +5,8 @@ import XCTest
 final class CheckoutEnvelopeTests: XCTestCase {
   func testJsonDecoding() {
     let json: [String: AnyObject] = [
-      "state": "failed",
-      "state_reason": "Oof!"
+      "state": "failed" as AnyObject,
+      "state_reason": "Oof!" as AnyObject
     ]
 
     let envelope = CheckoutEnvelope.decodeJSONDictionary(json)

--- a/KsApiTests/models/CheckoutEnvelopeTests.swift
+++ b/KsApiTests/models/CheckoutEnvelopeTests.swift
@@ -4,9 +4,9 @@ import XCTest
 
 final class CheckoutEnvelopeTests: XCTestCase {
   func testJsonDecoding() {
-    let json: [String: AnyObject] = [
-      "state": "failed" as AnyObject,
-      "state_reason": "Oof!" as AnyObject
+    let json: [String: Any] = [
+      "state": "failed",
+      "state_reason": "Oof!"
     ]
 
     let envelope = CheckoutEnvelope.decodeJSONDictionary(json)

--- a/KsApiTests/models/ConfigTests.swift
+++ b/KsApiTests/models/ConfigTests.swift
@@ -15,8 +15,8 @@ final class ConfigTests: XCTestCase {
       "feature2": false,
       ]
     let json: [String:AnyObject] = [
-      "ab_experiments": abExperiments,
-      "app_id": 123456789,
+      "ab_experiments": abExperiments as AnyObject,
+      "app_id": 123456789 as AnyObject,
       "apple_pay_countries": ["US", "GB", "CA"],
       "country_code": "US",
       "features": features,

--- a/KsApiTests/models/ConfigTests.swift
+++ b/KsApiTests/models/ConfigTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import KsApi
 import Argo
 import Curry
+import Runes
 
 final class ConfigTests: XCTestCase {
 
@@ -14,9 +15,9 @@ final class ConfigTests: XCTestCase {
       "feature1": true,
       "feature2": false,
       ]
-    let json: [String:AnyObject] = [
-      "ab_experiments": abExperiments as AnyObject,
-      "app_id": 123456789 as AnyObject,
+    let json: [String:Any] = [
+      "ab_experiments": abExperiments,
+      "app_id": 123456789,
       "apple_pay_countries": ["US", "GB", "CA"],
       "country_code": "US",
       "features": features,

--- a/KsApiTests/models/CreatePledgeEnvelopeTests.swift
+++ b/KsApiTests/models/CreatePledgeEnvelopeTests.swift
@@ -4,13 +4,13 @@ import XCTest
 final class CreatePledgeEnvelopeTests: XCTestCase {
 
   func testDecodingWithStringStatus() {
-    let decoded = CreatePledgeEnvelope.decodeJSONDictionary(["status" : "200"])
+    let decoded = CreatePledgeEnvelope.decodeJSONDictionary(["status": "200"])
     XCTAssertNil(decoded.error)
     XCTAssertEqual(200, decoded.value?.status)
   }
 
   func testDecodingWithIntStatus() {
-    let decoded = CreatePledgeEnvelope.decodeJSONDictionary(["status" : 200])
+    let decoded = CreatePledgeEnvelope.decodeJSONDictionary(["status": 200])
     XCTAssertNil(decoded.error)
     XCTAssertEqual(200, decoded.value?.status)
   }
@@ -21,7 +21,7 @@ final class CreatePledgeEnvelopeTests: XCTestCase {
   }
 
   func testDecodingWithBadStatusData() {
-    let decoded = CreatePledgeEnvelope.decodeJSONDictionary(["status" : "bad data"])
+    let decoded = CreatePledgeEnvelope.decodeJSONDictionary(["status": "bad data"])
     XCTAssertNil(decoded.error)
     XCTAssertEqual(0, decoded.value?.status)
   }

--- a/KsApiTests/models/FindFriendsEnvelopeTests.swift
+++ b/KsApiTests/models/FindFriendsEnvelopeTests.swift
@@ -5,7 +5,7 @@ final class FindFriendsEnvelopeTests: XCTestCase {
   // swiftlint:disable function_body_length
   func testJsonDecoding() {
     let json: [String: AnyObject] = [
-      "contacts_imported": true,
+      "contacts_imported": true as AnyObject,
       "urls": [
         "api": [
           "more_users": "http://api.dev/v1/users/self/friends/find?count=10"
@@ -68,7 +68,7 @@ final class FindFriendsEnvelopeTests: XCTestCase {
 
   func testJsonDecoding_MissingData() {
     let json: [String: AnyObject] = [
-      "contacts_imported": true,
+      "contacts_imported": true as AnyObject,
       "urls": [
         "api": [
         ]

--- a/KsApiTests/models/FindFriendsEnvelopeTests.swift
+++ b/KsApiTests/models/FindFriendsEnvelopeTests.swift
@@ -80,6 +80,6 @@ final class FindFriendsEnvelopeTests: XCTestCase {
     let friends = FindFriendsEnvelope.decodeJSONDictionary(json)
 
     XCTAssertNil(friends.value?.urls.api.moreUsers)
-    XCTAssertNil(friends.value?.users)
+    XCTAssertEqual([], friends.value?.users ?? [])
   }
 }

--- a/KsApiTests/models/FindFriendsEnvelopeTests.swift
+++ b/KsApiTests/models/FindFriendsEnvelopeTests.swift
@@ -4,8 +4,8 @@ import XCTest
 final class FindFriendsEnvelopeTests: XCTestCase {
   // swiftlint:disable function_body_length
   func testJsonDecoding() {
-    let json: [String: AnyObject] = [
-      "contacts_imported": true as AnyObject,
+    let json: [String:Any] = [
+      "contacts_imported": true,
       "urls": [
         "api": [
           "more_users": "http://api.dev/v1/users/self/friends/find?count=10"
@@ -67,8 +67,8 @@ final class FindFriendsEnvelopeTests: XCTestCase {
   // swiftlint:enable function_body_length
 
   func testJsonDecoding_MissingData() {
-    let json: [String: AnyObject] = [
-      "contacts_imported": true as AnyObject,
+    let json: [String:Any] = [
+      "contacts_imported": true,
       "urls": [
         "api": [
         ]

--- a/KsApiTests/models/FriendStatsEnvelopeTests.swift
+++ b/KsApiTests/models/FriendStatsEnvelopeTests.swift
@@ -4,11 +4,11 @@ import XCTest
 
 final class FriendStatsEnvelopeTests: XCTestCase {
   func testJsonDecoding() {
-    let json: [String: AnyObject] = [
+    let json: [String:Any] = [
       "stats": [
         "remote_friends_count": 202,
         "friend_projects_count": 1132
-      ] as AnyObject
+      ]
     ]
 
     let stats = FriendStatsEnvelope.decodeJSONDictionary(json)

--- a/KsApiTests/models/FriendStatsEnvelopeTests.swift
+++ b/KsApiTests/models/FriendStatsEnvelopeTests.swift
@@ -8,7 +8,7 @@ final class FriendStatsEnvelopeTests: XCTestCase {
       "stats": [
         "remote_friends_count": 202,
         "friend_projects_count": 1132
-      ]
+      ] as AnyObject
     ]
 
     let stats = FriendStatsEnvelope.decodeJSONDictionary(json)

--- a/KsApiTests/models/ItemTests.swift
+++ b/KsApiTests/models/ItemTests.swift
@@ -6,11 +6,11 @@ final class ItemTests: XCTestCase {
 
   func testDecoding() {
     let decoded = Item.decodeJSONDictionary([
-      "amount": 10.0 as AnyObject,
-      "description": "Hello" as AnyObject,
-      "id": 1 as AnyObject,
-      "name": "The thing" as AnyObject,
-      "project_id": 1 as AnyObject
+      "amount": 10.0,
+      "description": "Hello",
+      "id": 1,
+      "name": "The thing",
+      "project_id": 1
     ])
 
     XCTAssertNil(decoded.error)

--- a/KsApiTests/models/ItemTests.swift
+++ b/KsApiTests/models/ItemTests.swift
@@ -6,11 +6,11 @@ final class ItemTests: XCTestCase {
 
   func testDecoding() {
     let decoded = Item.decodeJSONDictionary([
-      "amount": 10.0,
-      "description": "Hello",
-      "id": 1,
-      "name": "The thing",
-      "project_id": 1
+      "amount": 10.0 as AnyObject,
+      "description": "Hello" as AnyObject,
+      "id": 1 as AnyObject,
+      "name": "The thing" as AnyObject,
+      "project_id": 1 as AnyObject
     ])
 
     XCTAssertNil(decoded.error)

--- a/KsApiTests/models/LocationTests.swift
+++ b/KsApiTests/models/LocationTests.swift
@@ -34,7 +34,7 @@ final class LocationTests: XCTestCase {
   }
 
   func testEncodeDecode() {
-    let location = [
+    let location: [String : Any] = [
       "country": "US",
       "id": 44,
       "displayable_name": "New Amsterdam, NY",

--- a/KsApiTests/models/LocationTests.swift
+++ b/KsApiTests/models/LocationTests.swift
@@ -34,7 +34,7 @@ final class LocationTests: XCTestCase {
   }
 
   func testEncodeDecode() {
-    let location: [String : Any] = [
+    let location: [String:Any] = [
       "country": "US",
       "id": 44,
       "displayable_name": "New Amsterdam, NY",

--- a/KsApiTests/models/LocationTests.swift
+++ b/KsApiTests/models/LocationTests.swift
@@ -44,6 +44,6 @@ final class LocationTests: XCTestCase {
     let decodedLocation = Location.decodeJSONDictionary(location).value
 
     XCTAssertEqual(decodedLocation, Location.decodeJSONDictionary(decodedLocation?.encode() ?? [:]).value)
-    XCTAssertEqual(decodedLocation?.encode() ?? [:], location as NSDictionary)
+    XCTAssertEqual(decodedLocation?.encode() as NSDictionary?, location as NSDictionary?)
   }
 }

--- a/KsApiTests/models/Project.CountryTests.swift
+++ b/KsApiTests/models/Project.CountryTests.swift
@@ -16,10 +16,10 @@ final class ProjectCountryTests: XCTestCase {
 
   func testJsonDecoding_StandardJSON() {
     let decodedCountry = Project.Country.decodeJSONDictionary([
-      "country": "US" as AnyObject,
-      "currency": "USD" as AnyObject,
-      "currency_symbol": "$" as AnyObject,
-      "currency_trailing_code": true as AnyObject
+      "country": "US",
+      "currency": "USD",
+      "currency_symbol": "$",
+      "currency_trailing_code": true
       ])
 
     XCTAssertEqual(.US, decodedCountry.value)
@@ -30,10 +30,10 @@ final class ProjectCountryTests: XCTestCase {
 
   func testJsonDecoding_ConfigJSON() {
     let decodedCountry = Project.Country.decodeJSONDictionary([
-      "name": "US" as AnyObject,
-      "currency_code": "USD" as AnyObject,
-      "currency_symbol": "$" as AnyObject,
-      "trailing_code": true as AnyObject
+      "name": "US",
+      "currency_code": "USD",
+      "currency_symbol": "$",
+      "trailing_code": true
       ])
 
     XCTAssertEqual(.US, decodedCountry.value)

--- a/KsApiTests/models/Project.CountryTests.swift
+++ b/KsApiTests/models/Project.CountryTests.swift
@@ -16,10 +16,10 @@ final class ProjectCountryTests: XCTestCase {
 
   func testJsonDecoding_StandardJSON() {
     let decodedCountry = Project.Country.decodeJSONDictionary([
-      "country": "US",
-      "currency": "USD",
-      "currency_symbol": "$",
-      "currency_trailing_code": true
+      "country": "US" as AnyObject,
+      "currency": "USD" as AnyObject,
+      "currency_symbol": "$" as AnyObject,
+      "currency_trailing_code": true as AnyObject
       ])
 
     XCTAssertEqual(.US, decodedCountry.value)
@@ -30,10 +30,10 @@ final class ProjectCountryTests: XCTestCase {
 
   func testJsonDecoding_ConfigJSON() {
     let decodedCountry = Project.Country.decodeJSONDictionary([
-      "name": "US",
-      "currency_code": "USD",
-      "currency_symbol": "$",
-      "trailing_code": true
+      "name": "US" as AnyObject,
+      "currency_code": "USD" as AnyObject,
+      "currency_symbol": "$" as AnyObject,
+      "trailing_code": true as AnyObject
       ])
 
     XCTAssertEqual(.US, decodedCountry.value)

--- a/KsApiTests/models/Project.PhotoTests.swift
+++ b/KsApiTests/models/Project.PhotoTests.swift
@@ -5,8 +5,8 @@ final class ProjectPhotoTests: XCTestCase {
 
   func testJSONParsing_WithPartialData() {
     let photo = Project.Photo.decodeJSONDictionary([
-      "full": "http://www.kickstarter.com/full.jpg",
-      "med": "http://www.kickstarter.com/med.jpg",
+      "full": "http://www.kickstarter.com/full.jpg" as AnyObject,
+      "med": "http://www.kickstarter.com/med.jpg" as AnyObject,
       ])
 
     XCTAssertNotNil(photo.error)
@@ -14,9 +14,9 @@ final class ProjectPhotoTests: XCTestCase {
 
   func testJSONParsing_WithMissing1024() {
     let photo = Project.Photo.decodeJSONDictionary([
-      "full": "http://www.kickstarter.com/full.jpg",
-      "med": "http://www.kickstarter.com/med.jpg",
-      "small": "http://www.kickstarter.com/small.jpg",
+      "full": "http://www.kickstarter.com/full.jpg" as AnyObject,
+      "med": "http://www.kickstarter.com/med.jpg" as AnyObject,
+      "small": "http://www.kickstarter.com/small.jpg" as AnyObject,
       ])
 
     XCTAssertNil(photo.error)
@@ -28,9 +28,9 @@ final class ProjectPhotoTests: XCTestCase {
 
   func testJSONParsing_WithFullData() {
     let photo = Project.Photo.decodeJSONDictionary([
-      "full": "http://www.kickstarter.com/full.jpg",
-      "med": "http://www.kickstarter.com/med.jpg",
-      "small": "http://www.kickstarter.com/small.jpg",
+      "full": "http://www.kickstarter.com/full.jpg" as AnyObject,
+      "med": "http://www.kickstarter.com/med.jpg" as AnyObject,
+      "small": "http://www.kickstarter.com/small.jpg" as AnyObject,
       "1024x768": "http://www.kickstarter.com/1024x768.jpg",
       ])
 

--- a/KsApiTests/models/Project.PhotoTests.swift
+++ b/KsApiTests/models/Project.PhotoTests.swift
@@ -5,8 +5,8 @@ final class ProjectPhotoTests: XCTestCase {
 
   func testJSONParsing_WithPartialData() {
     let photo = Project.Photo.decodeJSONDictionary([
-      "full": "http://www.kickstarter.com/full.jpg" as AnyObject,
-      "med": "http://www.kickstarter.com/med.jpg" as AnyObject,
+      "full": "http://www.kickstarter.com/full.jpg",
+      "med": "http://www.kickstarter.com/med.jpg",
       ])
 
     XCTAssertNotNil(photo.error)
@@ -14,9 +14,9 @@ final class ProjectPhotoTests: XCTestCase {
 
   func testJSONParsing_WithMissing1024() {
     let photo = Project.Photo.decodeJSONDictionary([
-      "full": "http://www.kickstarter.com/full.jpg" as AnyObject,
-      "med": "http://www.kickstarter.com/med.jpg" as AnyObject,
-      "small": "http://www.kickstarter.com/small.jpg" as AnyObject,
+      "full": "http://www.kickstarter.com/full.jpg",
+      "med": "http://www.kickstarter.com/med.jpg",
+      "small": "http://www.kickstarter.com/small.jpg",
       ])
 
     XCTAssertNil(photo.error)
@@ -28,9 +28,9 @@ final class ProjectPhotoTests: XCTestCase {
 
   func testJSONParsing_WithFullData() {
     let photo = Project.Photo.decodeJSONDictionary([
-      "full": "http://www.kickstarter.com/full.jpg" as AnyObject,
-      "med": "http://www.kickstarter.com/med.jpg" as AnyObject,
-      "small": "http://www.kickstarter.com/small.jpg" as AnyObject,
+      "full": "http://www.kickstarter.com/full.jpg",
+      "med": "http://www.kickstarter.com/med.jpg",
+      "small": "http://www.kickstarter.com/small.jpg",
       "1024x768": "http://www.kickstarter.com/1024x768.jpg",
       ])
 

--- a/KsApiTests/models/ProjectStatsEnvelopeTests.swift
+++ b/KsApiTests/models/ProjectStatsEnvelopeTests.swift
@@ -5,17 +5,17 @@ import XCTest
 final class ProjectStatsEnvelopeTests: XCTestCase {
   // swiftlint:disable function_body_length
   func testJSONDecoding() {
-    let fundingStats: [[String:AnyObject]] = [
+    let fundingStats: [[String:Any]] = [
       [
-        "cumulative_backers_count": 7 as AnyObject,
-        "cumulative_pledged": "30" as AnyObject,
-        "pledged": "38.0" as AnyObject,
-        "date": 555444333 as AnyObject,
-        "backers_count": 13 as AnyObject
+        "cumulative_backers_count": 7,
+        "cumulative_pledged": "30",
+        "pledged": "38.0",
+        "date": 555444333,
+        "backers_count": 13
       ],
       [
-        "cumulative_backers_count": 14 as AnyObject,
-        "cumulative_pledged": 1000 as AnyObject,
+        "cumulative_backers_count": 14,
+        "cumulative_pledged": 1000,
         "pledged": "909.0",
         "date": 333222111,
         "backers_count": 1
@@ -23,7 +23,7 @@ final class ProjectStatsEnvelopeTests: XCTestCase {
       ["date": 555444334],
       ["date": 555444335]
     ]
-    let json: [String: AnyObject] = [
+    let json: [String: Any] = [
       "referral_distribution": [
         [
           "code": "my_wonderful_referrer_code",
@@ -117,17 +117,12 @@ final class ProjectStatsEnvelopeTests: XCTestCase {
   // swiftlint:enable function_body_length
 
   func testJSONDecoding_MissingData() {
-    let json: [String: AnyObject] = [
-      "referral_distribution": [
-      ],
-      "reward_distribution": [
-      ],
-      "cumulative": [
-      ],
-      "funding_distribution": [
-      ],
-      "video_stats": [
-      ]
+    let json: [String: Any] = [
+      "referral_distribution": [],
+      "reward_distribution": [],
+      "cumulative": [],
+      "funding_distribution": [],
+      "video_stats": []
     ]
 
     let stats = ProjectStatsEnvelope.decodeJSONDictionary(json)

--- a/KsApiTests/models/ProjectStatsEnvelopeTests.swift
+++ b/KsApiTests/models/ProjectStatsEnvelopeTests.swift
@@ -23,7 +23,7 @@ final class ProjectStatsEnvelopeTests: XCTestCase {
       ["date": 555444334],
       ["date": 555444335]
     ]
-    let json: [String: Any] = [
+    let json: [String:Any] = [
       "referral_distribution": [
         [
           "code": "my_wonderful_referrer_code",
@@ -117,7 +117,7 @@ final class ProjectStatsEnvelopeTests: XCTestCase {
   // swiftlint:enable function_body_length
 
   func testJSONDecoding_MissingData() {
-    let json: [String: Any] = [
+    let json: [String:Any] = [
       "referral_distribution": [],
       "reward_distribution": [],
       "cumulative": [],

--- a/KsApiTests/models/ProjectStatsEnvelopeTests.swift
+++ b/KsApiTests/models/ProjectStatsEnvelopeTests.swift
@@ -7,15 +7,15 @@ final class ProjectStatsEnvelopeTests: XCTestCase {
   func testJSONDecoding() {
     let fundingStats: [[String:AnyObject]] = [
       [
-        "cumulative_backers_count": 7,
-        "cumulative_pledged": "30",
-        "pledged": "38.0",
-        "date": 555444333,
-        "backers_count": 13
+        "cumulative_backers_count": 7 as AnyObject,
+        "cumulative_pledged": "30" as AnyObject,
+        "pledged": "38.0" as AnyObject,
+        "date": 555444333 as AnyObject,
+        "backers_count": 13 as AnyObject
       ],
       [
-        "cumulative_backers_count": 14,
-        "cumulative_pledged": 1000,
+        "cumulative_backers_count": 14 as AnyObject,
+        "cumulative_pledged": 1000 as AnyObject,
         "pledged": "909.0",
         "date": 333222111,
         "backers_count": 1

--- a/KsApiTests/models/ProjectTests.swift
+++ b/KsApiTests/models/ProjectTests.swift
@@ -23,34 +23,34 @@ final class ProjectTests: XCTestCase {
   func testEndsIn48Hours_WithJustLaunchedProject() {
 
     let justLaunched = Project.template
-      |> Project.lens.dates.launchedAt .~ NSDate().timeIntervalSince1970
+      |> Project.lens.dates.launchedAt .~ Date().timeIntervalSince1970
 
     XCTAssertEqual(false, justLaunched.endsIn48Hours)
   }
 
   func testEndsIn48Hours_WithEndingSoonProject() {
     let endingSoon = Project.template
-      |> Project.lens.dates.deadline .~ (NSDate().timeIntervalSince1970 - 60.0 * 60.0)
+      |> Project.lens.dates.deadline .~ (Date().timeIntervalSince1970 - 60.0 * 60.0)
 
     XCTAssertEqual(true, endingSoon.endsIn48Hours)
   }
 
   func testEndsIn48Hours_WithTimeZoneEdgeCaseProject() {
     let edgeCase = Project.template
-      |> Project.lens.dates.deadline .~ (NSDate().timeIntervalSince1970 - 60.0 * 60.0 * 47.0)
+      |> Project.lens.dates.deadline .~ (Date().timeIntervalSince1970 - 60.0 * 60.0 * 47.0)
 
     XCTAssertEqual(true, edgeCase.endsIn48Hours)
   }
 
   func testIsPotdToday_OnPotd() {
-    let potdAt = NSCalendar.currentCalendar().startOfDayForDate(NSDate()).timeIntervalSince1970
+    let potdAt = Calendar.current.startOfDay(for: Date()).timeIntervalSince1970
     let potd = Project.template
       |> Project.lens.dates.potdAt .~ potdAt
 
     XCTAssertEqual(true, potd.isPotdToday())
-    XCTAssertEqual(true, potd.isPotdToday(today: NSDate()))
-    XCTAssertEqual(false, potd.isPotdToday(today: NSDate(timeIntervalSinceNow: 60.0 * 60.0 * 24)))
-    XCTAssertEqual(false, potd.isPotdToday(today: NSDate(timeIntervalSinceNow: -60.0 * 60.0 * 24)))
+    XCTAssertEqual(true, potd.isPotdToday(today: Date()))
+    XCTAssertEqual(false, potd.isPotdToday(today: Date(timeIntervalSinceNow: 60.0 * 60.0 * 24)))
+    XCTAssertEqual(false, potd.isPotdToday(today: Date(timeIntervalSinceNow: -60.0 * 60.0 * 24)))
   }
 
   func testIsPotdToday_WhenUnspecified() {

--- a/KsApiTests/models/RewardTests.swift
+++ b/KsApiTests/models/RewardTests.swift
@@ -22,16 +22,16 @@ final class RewardTests: XCTestCase {
     let reward4 = Reward.template |> Reward.lens.id .~ 2 <> Reward.lens.minimum .~ 30
 
     let rewards = [reward1, reward2, reward3, reward4]
-    let sorted = rewards.sort()
+    let sorted = rewards.sorted()
 
     XCTAssertEqual(sorted, [reward1, reward3, reward4, reward2])
   }
 
   func testJsonParsing_WithMinimalData_AndDescription() {
     let reward = Reward.decodeJSONDictionary([
-      "id": 1,
-      "minimum": 10,
-      "description": "cool stuff"
+      "id": 1 as AnyObject,
+      "minimum": 10 as AnyObject,
+      "description": "cool stuff" as AnyObject
       ])
 
     XCTAssertNil(reward.error)
@@ -44,9 +44,9 @@ final class RewardTests: XCTestCase {
 
   func testJsonParsing_WithMinimalData_AndReward() {
     let reward = Reward.decodeJSONDictionary([
-      "id": 1,
-      "minimum": 10,
-      "reward": "cool stuff"
+      "id": 1 as AnyObject,
+      "minimum": 10 as AnyObject,
+      "reward": "cool stuff" as AnyObject
       ])
 
     XCTAssertNil(reward.error)
@@ -57,10 +57,10 @@ final class RewardTests: XCTestCase {
 
   func testJsonParsing_WithFullData() {
     let reward = Reward.decodeJSONDictionary([
-      "id": 1,
-      "description": "Some reward",
-      "minimum": 10,
-      "backers_count": 10
+      "id": 1 as AnyObject,
+      "description": "Some reward" as AnyObject,
+      "minimum": 10 as AnyObject,
+      "backers_count": 10 as AnyObject
       ])
 
     XCTAssertNotNil(reward)
@@ -73,10 +73,10 @@ final class RewardTests: XCTestCase {
   func testJsonDecoding_WithShipping() {
 
     let reward = Reward.decodeJSONDictionary([
-      "id": 1,
-      "description": "Some reward",
-      "minimum": 10,
-      "backers_count": 10,
+      "id": 1 as AnyObject,
+      "description": "Some reward" as AnyObject,
+      "minimum": 10 as AnyObject,
+      "backers_count": 10 as AnyObject,
       "shipping_enabled": true,
       "shipping_preference": "unrestricted",
       "shipping_summary": "Ships anywhere in the world."

--- a/KsApiTests/models/RewardTests.swift
+++ b/KsApiTests/models/RewardTests.swift
@@ -29,9 +29,9 @@ final class RewardTests: XCTestCase {
 
   func testJsonParsing_WithMinimalData_AndDescription() {
     let reward = Reward.decodeJSONDictionary([
-      "id": 1 as AnyObject,
-      "minimum": 10 as AnyObject,
-      "description": "cool stuff" as AnyObject
+      "id": 1,
+      "minimum": 10,
+      "description": "cool stuff"
       ])
 
     XCTAssertNil(reward.error)
@@ -44,9 +44,9 @@ final class RewardTests: XCTestCase {
 
   func testJsonParsing_WithMinimalData_AndReward() {
     let reward = Reward.decodeJSONDictionary([
-      "id": 1 as AnyObject,
-      "minimum": 10 as AnyObject,
-      "reward": "cool stuff" as AnyObject
+      "id": 1,
+      "minimum": 10,
+      "reward": "cool stuff"
       ])
 
     XCTAssertNil(reward.error)
@@ -57,10 +57,10 @@ final class RewardTests: XCTestCase {
 
   func testJsonParsing_WithFullData() {
     let reward = Reward.decodeJSONDictionary([
-      "id": 1 as AnyObject,
-      "description": "Some reward" as AnyObject,
-      "minimum": 10 as AnyObject,
-      "backers_count": 10 as AnyObject
+      "id": 1,
+      "description": "Some reward",
+      "minimum": 10,
+      "backers_count": 10
       ])
 
     XCTAssertNotNil(reward)
@@ -73,10 +73,10 @@ final class RewardTests: XCTestCase {
   func testJsonDecoding_WithShipping() {
 
     let reward = Reward.decodeJSONDictionary([
-      "id": 1 as AnyObject,
-      "description": "Some reward" as AnyObject,
-      "minimum": 10 as AnyObject,
-      "backers_count": 10 as AnyObject,
+      "id": 1,
+      "description": "Some reward",
+      "minimum": 10,
+      "backers_count": 10,
       "shipping_enabled": true,
       "shipping_preference": "unrestricted",
       "shipping_summary": "Ships anywhere in the world."

--- a/KsApiTests/models/SubmitApplePayEnvelopeTests.swift
+++ b/KsApiTests/models/SubmitApplePayEnvelopeTests.swift
@@ -6,10 +6,10 @@ final class SubmitApplePayEnvelopeTests: XCTestCase {
   func testDecodingWithStringStatus() {
     let decoded = SubmitApplePayEnvelope.decodeJSONDictionary(
       [
-        "data" : [
-          "thankyou_url" : "https://www.kickstarter.com/thanks"
+        "data": [
+          "thankyou_url": "https://www.kickstarter.com/thanks"
         ],
-        "status" : "200"
+        "status": "200"
       ]
     )
 
@@ -20,10 +20,10 @@ final class SubmitApplePayEnvelopeTests: XCTestCase {
   func testDecodingWithStatus() {
     let decoded = SubmitApplePayEnvelope.decodeJSONDictionary(
       [
-        "data" : [
-          "thankyou_url" : "https://www.kickstarter.com/thanks"
+        "data": [
+          "thankyou_url": "https://www.kickstarter.com/thanks"
         ],
-        "status" : 200
+        "status": 200
       ]
     )
 
@@ -35,8 +35,8 @@ final class SubmitApplePayEnvelopeTests: XCTestCase {
 
     let decoded = SubmitApplePayEnvelope.decodeJSONDictionary(
       [
-        "data" : [
-          "thankyou_url" : "https://www.kickstarter.com/thanks"
+        "data": [
+          "thankyou_url": "https://www.kickstarter.com/thanks"
         ]
       ]
     )
@@ -47,10 +47,10 @@ final class SubmitApplePayEnvelopeTests: XCTestCase {
   func testDecodingWithBadStatusData() {
     let decoded = SubmitApplePayEnvelope.decodeJSONDictionary(
       [
-        "data" : [
-          "thankyou_url" : "bad data"
+        "data": [
+          "thankyou_url": "bad data"
         ],
-        "status" : "bad data"
+        "status": "bad data"
       ]
     )
 

--- a/KsApiTests/models/SurveyResponseTests.swift
+++ b/KsApiTests/models/SurveyResponseTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final internal class SurveyResponseTests: XCTestCase {
   func testJSONDecoding() {
     let decoded = SurveyResponse.decodeJSONDictionary([
-      "id": 1 as AnyObject,
+      "id": 1,
       "urls": [
         "web": [
           "survey": "http://"

--- a/KsApiTests/models/SurveyResponseTests.swift
+++ b/KsApiTests/models/SurveyResponseTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final internal class SurveyResponseTests: XCTestCase {
   func testJSONDecoding() {
     let decoded = SurveyResponse.decodeJSONDictionary([
-      "id": 1,
+      "id": 1 as AnyObject,
       "urls": [
         "web": [
           "survey": "http://"

--- a/KsApiTests/models/UpdateDraftTests.swift
+++ b/KsApiTests/models/UpdateDraftTests.swift
@@ -7,10 +7,10 @@ final class UpdateDraftTests: XCTestCase {
   func testJSONParsing_WithCompleteData() {
 
     let decoded = UpdateDraft.decodeJSONDictionary([
-      "body": "world" as AnyObject,
-      "id": 1 as AnyObject,
-      "public": true as AnyObject,
-      "project_id": 2 as AnyObject,
+      "body": "world",
+      "id": 1,
+      "public": true,
+      "project_id": 2,
       "sequence": 3,
       "title": "hello",
       "visible": true,

--- a/KsApiTests/models/UpdateDraftTests.swift
+++ b/KsApiTests/models/UpdateDraftTests.swift
@@ -7,10 +7,10 @@ final class UpdateDraftTests: XCTestCase {
   func testJSONParsing_WithCompleteData() {
 
     let decoded = UpdateDraft.decodeJSONDictionary([
-      "body": "world",
-      "id": 1,
-      "public": true,
-      "project_id": 2,
+      "body": "world" as AnyObject,
+      "id": 1 as AnyObject,
+      "public": true as AnyObject,
+      "project_id": 2 as AnyObject,
       "sequence": 3,
       "title": "hello",
       "visible": true,

--- a/KsApiTests/models/UpdatePledgeEnvelopeTests.swift
+++ b/KsApiTests/models/UpdatePledgeEnvelopeTests.swift
@@ -4,13 +4,13 @@ import XCTest
 final class UpdatePledgeEnvelopeTests: XCTestCase {
 
   func testDecodingWithStringStatus() {
-    let decoded = UpdatePledgeEnvelope.decodeJSONDictionary(["status" : "200"])
+    let decoded = UpdatePledgeEnvelope.decodeJSONDictionary(["status": "200"])
     XCTAssertNil(decoded.error)
     XCTAssertEqual(200, decoded.value?.status)
   }
 
   func testDecodingWithIntStatus() {
-    let decoded = UpdatePledgeEnvelope.decodeJSONDictionary(["status" : 200])
+    let decoded = UpdatePledgeEnvelope.decodeJSONDictionary(["status": 200])
     XCTAssertNil(decoded.error)
     XCTAssertEqual(200, decoded.value?.status)
   }
@@ -21,7 +21,7 @@ final class UpdatePledgeEnvelopeTests: XCTestCase {
   }
 
   func testDecodingWithBadStatusData() {
-    let decoded = UpdatePledgeEnvelope.decodeJSONDictionary(["status" : "bad data"])
+    let decoded = UpdatePledgeEnvelope.decodeJSONDictionary(["status": "bad data"])
     XCTAssertNil(decoded.error)
     XCTAssertEqual(0, decoded.value?.status)
   }

--- a/KsApiTests/models/User.AvatarTests.swift
+++ b/KsApiTests/models/User.AvatarTests.swift
@@ -5,8 +5,8 @@ final class UserAvatarTests: XCTestCase {
 
   func testJsonEncoding() {
     let json: [String:AnyObject] = [
-      "medium": "http://www.kickstarter.com/medium.jpg",
-      "small": "http://www.kickstarter.com/small.jpg"
+      "medium": "http://www.kickstarter.com/medium.jpg" as AnyObject,
+      "small": "http://www.kickstarter.com/small.jpg" as AnyObject
     ]
     let avatar = User.Avatar.decodeJSONDictionary(json)
 

--- a/KsApiTests/models/User.AvatarTests.swift
+++ b/KsApiTests/models/User.AvatarTests.swift
@@ -4,9 +4,9 @@ import XCTest
 final class UserAvatarTests: XCTestCase {
 
   func testJsonEncoding() {
-    let json: [String:AnyObject] = [
-      "medium": "http://www.kickstarter.com/medium.jpg" as AnyObject,
-      "small": "http://www.kickstarter.com/small.jpg" as AnyObject
+    let json: [String:Any] = [
+      "medium": "http://www.kickstarter.com/medium.jpg",
+      "small": "http://www.kickstarter.com/small.jpg"
     ]
     let avatar = User.Avatar.decodeJSONDictionary(json)
 

--- a/KsApiTests/models/User.NewsletterSubscriptionsTests.swift
+++ b/KsApiTests/models/User.NewsletterSubscriptionsTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class NewsletterSubscriptionsTests: XCTestCase {
 
   func testJsonEncoding() {
-    let json: [String: Any] = [
+    let json: [String:Any] = [
       "games_newsletter": false,
       "promo_newsletter": false,
       "happening_newsletter": false,
@@ -22,11 +22,11 @@ final class NewsletterSubscriptionsTests: XCTestCase {
   }
 
   func testJsonEncoding_TrueValues() {
-    let json: [String: AnyObject] = [
-      "games_newsletter": true as AnyObject,
-      "promo_newsletter": true as AnyObject,
-      "happening_newsletter": true as AnyObject,
-      "weekly_newsletter": true as AnyObject
+    let json: [String:Any] = [
+      "games_newsletter": true,
+      "promo_newsletter": true,
+      "happening_newsletter": true,
+      "weekly_newsletter": true
     ]
 
     let newsletter = User.NewsletterSubscriptions.decodeJSONDictionary(json)
@@ -41,9 +41,9 @@ final class NewsletterSubscriptionsTests: XCTestCase {
 
   func testJsonDecoding() {
     let json = User.NewsletterSubscriptions.decodeJSONDictionary([
-      "games_newsletter": true as AnyObject,
-      "happening_newsletter": false as AnyObject,
-      "promo_newsletter": true as AnyObject,
+      "games_newsletter": true,
+      "happening_newsletter": false,
+      "promo_newsletter": true,
       "weekly_newsletter": false
     ])
 

--- a/KsApiTests/models/User.NewsletterSubscriptionsTests.swift
+++ b/KsApiTests/models/User.NewsletterSubscriptionsTests.swift
@@ -4,11 +4,11 @@ import XCTest
 final class NewsletterSubscriptionsTests: XCTestCase {
 
   func testJsonEncoding() {
-    let json: [String: AnyObject] = [
-      "games_newsletter": false as AnyObject,
-      "promo_newsletter": false as AnyObject,
-      "happening_newsletter": false as AnyObject,
-      "weekly_newsletter": false as AnyObject
+    let json: [String: Any] = [
+      "games_newsletter": false,
+      "promo_newsletter": false,
+      "happening_newsletter": false,
+      "weekly_newsletter": false
     ]
 
     let newsletter = User.NewsletterSubscriptions.decodeJSONDictionary(json)
@@ -41,9 +41,9 @@ final class NewsletterSubscriptionsTests: XCTestCase {
 
   func testJsonDecoding() {
     let json = User.NewsletterSubscriptions.decodeJSONDictionary([
-      "games_newsletter": true,
-      "happening_newsletter": false,
-      "promo_newsletter": true,
+      "games_newsletter": true as AnyObject,
+      "happening_newsletter": false as AnyObject,
+      "promo_newsletter": true as AnyObject,
       "weekly_newsletter": false
     ])
 

--- a/KsApiTests/models/User.NewsletterSubscriptionsTests.swift
+++ b/KsApiTests/models/User.NewsletterSubscriptionsTests.swift
@@ -5,10 +5,10 @@ final class NewsletterSubscriptionsTests: XCTestCase {
 
   func testJsonEncoding() {
     let json: [String: AnyObject] = [
-      "games_newsletter": false,
-      "promo_newsletter": false,
-      "happening_newsletter": false,
-      "weekly_newsletter": false
+      "games_newsletter": false as AnyObject,
+      "promo_newsletter": false as AnyObject,
+      "happening_newsletter": false as AnyObject,
+      "weekly_newsletter": false as AnyObject
     ]
 
     let newsletter = User.NewsletterSubscriptions.decodeJSONDictionary(json)
@@ -23,10 +23,10 @@ final class NewsletterSubscriptionsTests: XCTestCase {
 
   func testJsonEncoding_TrueValues() {
     let json: [String: AnyObject] = [
-      "games_newsletter": true,
-      "promo_newsletter": true,
-      "happening_newsletter": true,
-      "weekly_newsletter": true
+      "games_newsletter": true as AnyObject,
+      "promo_newsletter": true as AnyObject,
+      "happening_newsletter": true as AnyObject,
+      "weekly_newsletter": true as AnyObject
     ]
 
     let newsletter = User.NewsletterSubscriptions.decodeJSONDictionary(json)

--- a/KsApiTests/models/User.NotificationsTests.swift
+++ b/KsApiTests/models/User.NotificationsTests.swift
@@ -4,13 +4,13 @@ import XCTest
 final class NotificationsTests: XCTestCase {
   func testJsonEncoding() {
     let json: [String: AnyObject] = [
-      "notify_of_backings": false,
-      "notify_of_comments": false,
-      "notify_of_follower": false,
-      "notify_of_friend_activity": false,
-      "notify_of_post_likes": false,
-      "notify_of_updates": false,
-      "notify_mobile_of_backings": false,
+      "notify_of_backings": false as AnyObject,
+      "notify_of_comments": false as AnyObject,
+      "notify_of_follower": false as AnyObject,
+      "notify_of_friend_activity": false as AnyObject,
+      "notify_of_post_likes": false as AnyObject,
+      "notify_of_updates": false as AnyObject,
+      "notify_mobile_of_backings": false as AnyObject,
       "notify_mobile_of_comments": false,
       "notify_mobile_of_follower": false,
       "notify_mobile_of_friend_activity": false,
@@ -39,13 +39,13 @@ final class NotificationsTests: XCTestCase {
 
   func testJsonEncoding_TrueValues() {
     let json: [String: AnyObject] = [
-      "notify_of_backings": true,
-      "notify_of_comments": true,
-      "notify_of_follower": true,
-      "notify_of_friend_activity": true,
-      "notify_of_post_likes": true,
-      "notify_of_updates": true,
-      "notify_mobile_of_backings": true,
+      "notify_of_backings": true as AnyObject,
+      "notify_of_comments": true as AnyObject,
+      "notify_of_follower": true as AnyObject,
+      "notify_of_friend_activity": true as AnyObject,
+      "notify_of_post_likes": true as AnyObject,
+      "notify_of_updates": true as AnyObject,
+      "notify_mobile_of_backings": true as AnyObject,
       "notify_mobile_of_comments": true,
       "notify_mobile_of_follower": true,
       "notify_mobile_of_friend_activity": true,

--- a/KsApiTests/models/User.NotificationsTests.swift
+++ b/KsApiTests/models/User.NotificationsTests.swift
@@ -1,16 +1,17 @@
+
 import XCTest
 @testable import KsApi
 
 final class NotificationsTests: XCTestCase {
   func testJsonEncoding() {
-    let json: [String: AnyObject] = [
-      "notify_of_backings": false as AnyObject,
-      "notify_of_comments": false as AnyObject,
-      "notify_of_follower": false as AnyObject,
-      "notify_of_friend_activity": false as AnyObject,
-      "notify_of_post_likes": false as AnyObject,
-      "notify_of_updates": false as AnyObject,
-      "notify_mobile_of_backings": false as AnyObject,
+    let json: [String:Any] = [
+      "notify_of_backings": false,
+      "notify_of_comments": false,
+      "notify_of_follower": false,
+      "notify_of_friend_activity": false,
+      "notify_of_post_likes": false,
+      "notify_of_updates": false,
+      "notify_mobile_of_backings": false,
       "notify_mobile_of_comments": false,
       "notify_mobile_of_follower": false,
       "notify_mobile_of_friend_activity": false,
@@ -21,7 +22,7 @@ final class NotificationsTests: XCTestCase {
     let notification = User.Notifications.decodeJSONDictionary(json)
 
     XCTAssertNil(notification.error)
-    XCTAssertEqual(notification.value?.encode(), json as NSDictionary)
+    XCTAssertEqual(notification.value?.encode() as NSDictionary?, json as NSDictionary?)
 
     XCTAssertEqual(false, notification.value?.backings)
     XCTAssertEqual(false, notification.value?.comments)
@@ -38,14 +39,14 @@ final class NotificationsTests: XCTestCase {
   }
 
   func testJsonEncoding_TrueValues() {
-    let json: [String: AnyObject] = [
-      "notify_of_backings": true as AnyObject,
-      "notify_of_comments": true as AnyObject,
-      "notify_of_follower": true as AnyObject,
-      "notify_of_friend_activity": true as AnyObject,
-      "notify_of_post_likes": true as AnyObject,
-      "notify_of_updates": true as AnyObject,
-      "notify_mobile_of_backings": true as AnyObject,
+    let json: [String: Any] = [
+      "notify_of_backings": true,
+      "notify_of_comments": true,
+      "notify_of_follower": true,
+      "notify_of_friend_activity": true,
+      "notify_of_post_likes": true,
+      "notify_of_updates": true,
+      "notify_mobile_of_backings": true,
       "notify_mobile_of_comments": true,
       "notify_mobile_of_follower": true,
       "notify_mobile_of_friend_activity": true,
@@ -56,7 +57,7 @@ final class NotificationsTests: XCTestCase {
     let notification = User.Notifications.decodeJSONDictionary(json)
 
     XCTAssertNil(notification.error)
-    XCTAssertEqual(notification.value?.encode(), json as NSDictionary)
+    XCTAssertEqual(notification.value?.encode() as NSDictionary?, json as NSDictionary?)
 
     XCTAssertEqual(true, notification.value?.backings)
     XCTAssertEqual(true, notification.value?.comments)

--- a/KsApiTests/models/User.NotificationsTests.swift
+++ b/KsApiTests/models/User.NotificationsTests.swift
@@ -1,4 +1,3 @@
-
 import XCTest
 @testable import KsApi
 

--- a/KsApiTests/models/User.NotificationsTests.swift
+++ b/KsApiTests/models/User.NotificationsTests.swift
@@ -38,7 +38,7 @@ final class NotificationsTests: XCTestCase {
   }
 
   func testJsonEncoding_TrueValues() {
-    let json: [String: Any] = [
+    let json: [String:Any] = [
       "notify_of_backings": true,
       "notify_of_comments": true,
       "notify_of_follower": true,

--- a/KsApiTests/models/UserTests.swift
+++ b/KsApiTests/models/UserTests.swift
@@ -35,7 +35,7 @@ final class UserTests: XCTestCase {
         "name": "Brooklyn"
       ],
       "is_friend": false
-    ]
+    ] as [String : Any]
     let decoded = User.decodeJSONDictionary(json)
     let user = decoded.value
 
@@ -55,8 +55,8 @@ final class UserTests: XCTestCase {
 
   func testJsonEncoding() {
     let json: [String:AnyObject] = [
-      "id": 1,
-      "name": "Blob",
+      "id": 1 as AnyObject,
+      "name": "Blob" as AnyObject,
       "avatar": [
         "medium": "http://www.kickstarter.com/medium.jpg",
         "small": "http://www.kickstarter.com/small.jpg",

--- a/KsApiTests/models/UserTests.swift
+++ b/KsApiTests/models/UserTests.swift
@@ -15,7 +15,7 @@ final class UserTests: XCTestCase {
   }
 
   func testJsonParsing() {
-    let json: [String : Any] = [
+    let json: [String:Any] = [
       "id": 1,
       "name": "Blob",
       "avatar": [

--- a/KsApiTests/models/UserTests.swift
+++ b/KsApiTests/models/UserTests.swift
@@ -15,7 +15,7 @@ final class UserTests: XCTestCase {
   }
 
   func testJsonParsing() {
-    let json = [
+    let json: [String : Any] = [
       "id": 1,
       "name": "Blob",
       "avatar": [
@@ -35,7 +35,7 @@ final class UserTests: XCTestCase {
         "name": "Brooklyn"
       ],
       "is_friend": false
-    ] as [String : Any]
+    ]
     let decoded = User.decodeJSONDictionary(json)
     let user = decoded.value
 
@@ -50,13 +50,13 @@ final class UserTests: XCTestCase {
     XCTAssertEqual(false, user?.facebookConnected)
     XCTAssertEqual(false, user?.isFriend)
     XCTAssertNotNil(user?.location)
-    XCTAssertEqual(json, user?.encode() as! [String:NSObject])
+    XCTAssertEqual(json as NSDictionary?, user?.encode() as NSDictionary?)
   }
 
   func testJsonEncoding() {
-    let json: [String:AnyObject] = [
-      "id": 1 as AnyObject,
-      "name": "Blob" as AnyObject,
+    let json: [String:Any] = [
+      "id": 1,
+      "name": "Blob",
       "avatar": [
         "medium": "http://www.kickstarter.com/medium.jpg",
         "small": "http://www.kickstarter.com/small.jpg",
@@ -78,6 +78,6 @@ final class UserTests: XCTestCase {
     ]
     let user = User.decodeJSONDictionary(json)
 
-    XCTAssertEqual(user.value?.encode(), json as NSDictionary)
+    XCTAssertEqual(user.value?.encode() as NSDictionary?, json as NSDictionary?)
   }
 }

--- a/bin/test
+++ b/bin/test
@@ -8,13 +8,13 @@ if [ $# -eq 0 ]; then
 fi
 
 if [ "$1" == "iOS" ]; then
-  DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=9.3'
+  DESTINATION='platform=iOS Simulator,name=iPhone 6,OS='
 else
-  DESTINATION='platform=tvOS Simulator,name=Apple TV 1080p'
+  DESTINATION='platform=tvOS Simulator,name=Apple TV 1080p,OS='
 fi
 
 xcodebuild \
-  -destination "$DESTINATION" \
+  -destination "$DESTINATION$2" \
   -scheme KsApi-$1 \
   clean test \
   | tee $CIRCLE_ARTIFACTS/xcode_raw.log \

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: 7.3
+    version: 8.2
 dependencies:
   pre:
     - bin/bootstrap

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,11 @@ dependencies:
     - bin/bootstrap
     - brew update || brew update
     - brew install swiftlint
+    - system_profiler SPSoftwareDataType
+    - security list-keychains
+    - security find-identity -p codesigning
+    - instruments -s devices
+    - xcodebuild -showsdks
   override:
     - git submodule sync --recursive
     - git submodule update --init --recursive || git submodule foreach git fetch origin --tags
@@ -18,7 +23,9 @@ test:
     - set -o pipefail &&
       swiftlint lint --strict --reporter json |
       tee $CIRCLE_ARTIFACTS/swiftlint-report.json
-    - bin/test iOS
+    - bin/test iOS 9.3
+    - bin/test iOS 10.1
+    - bin/test tvOS 10.1
 experimental:
   notify:
     branches:


### PR DESCRIPTION
This updates KsApi to be Swift 3 compatible. This does not change our APIs to be more "Swift 3 like". We should do that in a separate PR so that we can concentrate only on Swift 3 and not a bunch of other API-breaking changes.

This PR depends on the following other PR's:

https://github.com/kickstarter/Kickstarter-Prelude/pull/62
https://github.com/kickstarter/Kickstarter-ReactiveExtensions/pull/54

#### Notes

This migration was way bigger and more subtle than the other two. Some things to look out for:

* We had to upgrade Argo to [4.1.0](https://github.com/thoughtbot/Argo/releases/tag/v4.1.0), which came with a few changes from our current version:
  * Argo now requires [Runes](https://github.com/thoughtbot/Runes) as an explicit dependency (used to just be a submodule managed by Carthage). This just means we gotta `import Runes`anytime we do Argo stuff.
  * The semantics of decoding an optional has slightly changed https://github.com/thoughtbot/Argo/pull/420. It's for the better, but it's subtle and caused a few things to break in our tests. It all stems from the decision of how to handle decoding an optional value that fails. Should that fail the whole decoding, or should it be lifted to a `.success(nil)`?
* A _ton_ of `AnyObject`s have changed to `Any`s. I'm not entirely up-to-date with what changed in Swift to require this, but it's def for the better.
* I've got more notes, but I'll do em inline...