### PR TITLE
Live stream support updates

### DIFF
--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -145,6 +145,11 @@ public func == (lhs: Project, rhs: Project) -> Bool {
   return lhs.id == rhs.id
 }
 
+extension Project.LiveStream: Equatable {}
+public func == (lhs: Project.LiveStream, rhs: Project.LiveStream) -> Bool {
+  return lhs.id == rhs.id
+}
+
 extension Project: CustomDebugStringConvertible {
   public var debugDescription: String {
     return "Project(id: \(self.id), name: \"\(self.name)\")"

--- a/KsApi/models/PushEnvelope.swift
+++ b/KsApi/models/PushEnvelope.swift
@@ -6,6 +6,7 @@ public struct PushEnvelope {
   public let activity: Activity?
   public let aps: ApsEnvelope
   public let forCreator: Bool?
+  public let liveStream: LiveStream?
   public let message: Message?
   public let project: Project?
   public let survey: Survey?
@@ -23,6 +24,10 @@ public struct PushEnvelope {
 
   public struct ApsEnvelope {
     public let alert: String
+  }
+
+  public struct LiveStream {
+    public let id: Int
   }
 
   public struct Message {
@@ -57,6 +62,7 @@ extension PushEnvelope: Decodable {
       <^> json <|? "activity"
       <*> json <| "aps"
       <*> json <|? "for_creator"
+      <*> json <|? "live_stream"
     return tmp
       <*> json <|? "message"
       <*> json <|? "project"
@@ -84,6 +90,13 @@ extension PushEnvelope.ApsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<PushEnvelope.ApsEnvelope> {
     return curry(PushEnvelope.ApsEnvelope.init)
       <^> json <| "alert"
+  }
+}
+
+extension PushEnvelope.LiveStream: Decodable {
+  public static func decode(_ json: JSON) -> Decoded<PushEnvelope.LiveStream> {
+    return curry(PushEnvelope.LiveStream.init)
+      <^> json <| "id"
   }
 }
 

--- a/KsApi/models/lenses/ConfigLenses.swift
+++ b/KsApi/models/lenses/ConfigLenses.swift
@@ -14,9 +14,17 @@ extension Config {
     public static let countryCode = Lens<Config, String>(
       view: { $0.countryCode },
       set: { Config(abExperiments: $1.abExperiments, appId: $1.appId, applePayCountries: $1.applePayCountries,
-        countryCode: $0, features: $1.features, iTunesLink: $1.iTunesLink,
-        launchedCountries: $1.launchedCountries, locale: $1.locale,
-        stripePublishableKey: $1.stripePublishableKey) }
+                    countryCode: $0, features: $1.features, iTunesLink: $1.iTunesLink,
+                    launchedCountries: $1.launchedCountries, locale: $1.locale,
+                    stripePublishableKey: $1.stripePublishableKey) }
+    )
+
+    public static let features = Lens<Config, [String:Bool]>(
+      view: { $0.features },
+      set: { Config(abExperiments: $1.abExperiments, appId: $1.appId, applePayCountries: $1.applePayCountries,
+                    countryCode: $1.countryCode, features: $0, iTunesLink: $1.iTunesLink,
+                    launchedCountries: $1.launchedCountries, locale: $1.locale,
+                    stripePublishableKey: $1.stripePublishableKey) }
     )
 
     public static let launchedCountries = Lens<Config, [Project.Country]>(

--- a/KsApi/models/lenses/PushEnvelopeLenses.swift
+++ b/KsApi/models/lenses/PushEnvelopeLenses.swift
@@ -5,44 +5,50 @@ extension PushEnvelope {
   public enum lens {
     public static let activity = Lens<PushEnvelope, PushEnvelope.Activity?>(
       view: { $0.activity },
-      set: { .init(activity: $0, aps: $1.aps, forCreator: $1.forCreator, message: $1.message,
-        project: $1.project, survey: $1.survey, update: $1.update) }
+      set: { .init(activity: $0, aps: $1.aps, forCreator: $1.forCreator, liveStream: $1.liveStream,
+                   message: $1.message, project: $1.project, survey: $1.survey, update: $1.update) }
     )
 
     public static let aps = Lens<PushEnvelope, PushEnvelope.ApsEnvelope>(
       view: { $0.aps },
-      set: { .init(activity: $1.activity, aps: $0, forCreator: $1.forCreator, message: $1.message,
-        project: $1.project, survey: $1.survey, update: $1.update) }
+      set: { .init(activity: $1.activity, aps: $0, forCreator: $1.forCreator, liveStream: $1.liveStream,
+                   message: $1.message, project: $1.project, survey: $1.survey, update: $1.update) }
     )
 
     public static let forCreator = Lens<PushEnvelope, Bool?>(
       view: { $0.forCreator },
-      set: { .init(activity: $1.activity, aps: $1.aps, forCreator: $0, message: $1.message,
-        project: $1.project, survey: $1.survey, update: $1.update) }
+      set: { .init(activity: $1.activity, aps: $1.aps, forCreator: $0, liveStream: $1.liveStream,
+                   message: $1.message, project: $1.project, survey: $1.survey, update: $1.update) }
+    )
+
+    public static let liveStream = Lens<PushEnvelope, PushEnvelope.LiveStream?>(
+      view: { $0.liveStream },
+      set: { .init(activity: $1.activity, aps: $1.aps, forCreator: $1.forCreator, liveStream: $0,
+                   message: $1.message, project: $1.project, survey: $1.survey, update: $1.update) }
     )
 
     public static let message = Lens<PushEnvelope, PushEnvelope.Message?>(
       view: { $0.message },
-      set: { .init(activity: $1.activity, aps: $1.aps, forCreator: $1.forCreator, message: $0,
-        project: $1.project, survey: $1.survey, update: $1.update) }
+      set: { .init(activity: $1.activity, aps: $1.aps, forCreator: $1.forCreator, liveStream: $1.liveStream,
+                   message: $0, project: $1.project, survey: $1.survey, update: $1.update) }
     )
 
     public static let project = Lens<PushEnvelope, PushEnvelope.Project?>(
       view: { $0.project },
-      set: { .init(activity: $1.activity, aps: $1.aps, forCreator: $1.forCreator, message: $1.message,
-        project: $0, survey: $1.survey, update: $1.update) }
+      set: { .init(activity: $1.activity, aps: $1.aps, forCreator: $1.forCreator, liveStream: $1.liveStream,
+                   message: $1.message, project: $0, survey: $1.survey, update: $1.update) }
     )
 
     public static let survey = Lens<PushEnvelope, PushEnvelope.Survey?>(
       view: { $0.survey },
-      set: { .init(activity: $1.activity, aps: $1.aps, forCreator: $1.forCreator, message: $1.message,
-        project: $1.project, survey: $0, update: $1.update) }
+      set: { .init(activity: $1.activity, aps: $1.aps, forCreator: $1.forCreator, liveStream: $1.liveStream,
+                   message: $1.message, project: $1.project, survey: $0, update: $1.update) }
     )
 
     public static let update = Lens<PushEnvelope, PushEnvelope.Update?>(
       view: { $0.update },
-      set: { .init(activity: $1.activity, aps: $1.aps, forCreator: $1.forCreator, message: $1.message,
-        project: $1.project, survey: $1.survey, update: $0) }
+      set: { .init(activity: $1.activity, aps: $1.aps, forCreator: $1.forCreator, liveStream: $1.liveStream,
+                   message: $1.message, project: $1.project, survey: $1.survey, update: $0) }
     )
   }
 }


### PR DESCRIPTION
Just a few small updates for our upcoming live stream feature:

* support for live stream push notifications by adding a `live_stream` key to the push envelope (this really should be an enum huh?)
* equality of live streams cause it helps testing
* `features` lens on `Config` cause we are using our first feature flag with live stream (neat!) and i wanna be able to write tests for it (double neat!)