### PR TITLE
Make `liveStreams` optional in project model

### DIFF
--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -11,7 +11,7 @@ public struct Project {
   public let memberData: MemberData
   public let dates: Dates
   public let id: Int
-  public let liveStreams: [LiveStream]
+  public let liveStreams: [LiveStream]?
   public let location: Location
   public let name: String
   public let personalization: Personalization
@@ -168,7 +168,7 @@ extension Project: Decodable {
       <*> Project.MemberData.decode(json)
       <*> Project.Dates.decode(json)
       <*> json <| "id"
-      <*> (json <|| "livestreams" <|> .success([]))
+      <*> json <||? "livestreams"
       <*> (json <| "location" <|> .success(Location.none))
     let tmp3 = tmp2
       <*> json <| "name"

--- a/KsApi/models/lenses/ProjectLenses.swift
+++ b/KsApi/models/lenses/ProjectLenses.swift
@@ -57,7 +57,7 @@ extension Project {
         state: $1.state, stats: $1.stats, urls: $1.urls, video: $1.video) }
     )
 
-    public static let liveStreams = Lens<Project, [LiveStream]>(
+    public static let liveStreams = Lens<Project, [LiveStream]?>(
       view: { $0.liveStreams },
       set: { Project(blurb: $1.blurb, category: $1.category, country: $1.country,
         creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,

--- a/KsApi/models/templates/ProjectTemplates.swift
+++ b/KsApi/models/templates/ProjectTemplates.swift
@@ -21,7 +21,7 @@ extension Project {
       stateChangedAt: Date().timeIntervalSince1970 - 60.0 * 60.0 * 24.0 * 15.0
     ),
     id: 1,
-    liveStreams: [],
+    liveStreams: nil,
     location: .template,
     name: "The Project",
     personalization: Project.Personalization(


### PR DESCRIPTION
We need to make `project.liveStreams` optional in the project model instead of coalescing a missing `livestreams` key to the empty array `[]`.

In this PR https://github.com/kickstarter/ios-oss/pull/54/files to add analytics tracking to our live streaming, we wanted to track a property that determines if live streams are available from the project page. Unfortunately, the project model does not have that info when the project page is first opened, and instead requires an API request to get it. So, we need to be able to distinguish the situation of not having live stream data _yet_ and having no live streams.