### PR TITLE
Live Auth Token endpoint

### DIFF
--- a/KsApi.xcodeproj/project.pbxproj
+++ b/KsApi.xcodeproj/project.pbxproj
@@ -389,6 +389,9 @@
 		A7FD09C81C83E8E900332CCB /* KsApiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A753B56B1C2EED9800FDB616 /* KsApiTests.swift */; };
 		A7FD09CA1C83E8E900332CCB /* KsApi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43C5F91BB358F200C180DA /* KsApi.framework */; };
 		CA43C5FD1BB358F200C180DA /* KsApi.h in Headers */ = {isa = PBXBuildFile; fileRef = CA43C5FC1BB358F200C180DA /* KsApi.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D0BC0E841E709202006C6D41 /* LiveAuthTokenEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BC0E831E709202006C6D41 /* LiveAuthTokenEnvelope.swift */; };
+		D0BC0E9A1E709427006C6D41 /* LiveAuthTokenEnvelopeTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BC0E991E709427006C6D41 /* LiveAuthTokenEnvelopeTemplates.swift */; };
+		D0BC0E9C1E7094BA006C6D41 /* LiveAuthTokenEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BC0E9B1E7094BA006C6D41 /* LiveAuthTokenEnvelopeTests.swift */; };
 		D7C6C7B41DF607B0005DC734 /* CreatePledgeEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C6C7B31DF607B0005DC734 /* CreatePledgeEnvelopeTests.swift */; };
 		D7C6C7B51DF607B0005DC734 /* CreatePledgeEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C6C7B31DF607B0005DC734 /* CreatePledgeEnvelopeTests.swift */; };
 		D7C6C7C61DF63648005DC734 /* ChangePaymentMethodEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C6C7C51DF63648005DC734 /* ChangePaymentMethodEnvelopeTests.swift */; };
@@ -920,6 +923,9 @@
 		CA43C5F91BB358F200C180DA /* KsApi.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KsApi.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA43C5FC1BB358F200C180DA /* KsApi.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KsApi.h; sourceTree = "<group>"; };
 		CA43C5FE1BB358F200C180DA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D0BC0E831E709202006C6D41 /* LiveAuthTokenEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveAuthTokenEnvelope.swift; sourceTree = "<group>"; };
+		D0BC0E991E709427006C6D41 /* LiveAuthTokenEnvelopeTemplates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveAuthTokenEnvelopeTemplates.swift; sourceTree = "<group>"; };
+		D0BC0E9B1E7094BA006C6D41 /* LiveAuthTokenEnvelopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveAuthTokenEnvelopeTests.swift; sourceTree = "<group>"; };
 		D7C6C7B31DF607B0005DC734 /* CreatePledgeEnvelopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreatePledgeEnvelopeTests.swift; sourceTree = "<group>"; };
 		D7C6C7C51DF63648005DC734 /* ChangePaymentMethodEnvelopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangePaymentMethodEnvelopeTests.swift; sourceTree = "<group>"; };
 		D7C6C7C81DF63861005DC734 /* SubmitApplePayEnvelopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubmitApplePayEnvelopeTests.swift; sourceTree = "<group>"; };
@@ -996,6 +1002,7 @@
 				0156B3811D0F7DC7000C4252 /* FindFriendsEnvelopeTemplates.swift */,
 				0156B41B1D10D4F9000C4252 /* FriendStatsEnvelopeTemplates.swift */,
 				A747A8091D455AD000AF199A /* ItemTemplates.swift */,
+				D0BC0E991E709427006C6D41 /* LiveAuthTokenEnvelopeTemplates.swift */,
 				A72661E31D07671D0087D883 /* LocationTemplates.swift */,
 				A72661E41D07671D0087D883 /* MessageTemplates.swift */,
 				A72661E51D07671D0087D883 /* MessageThreadTemplates.swift */,
@@ -1127,6 +1134,7 @@
 				A777A5931D05F55A00823FB1 /* FindFriendsEnvelope.swift */,
 				A777A5941D05F55A00823FB1 /* FriendStatsEnvelope.swift */,
 				A747A7EB1D455A3F00AF199A /* Item.swift */,
+				D0BC0E831E709202006C6D41 /* LiveAuthTokenEnvelope.swift */,
 				A73639B71D03565400445B24 /* Location.swift */,
 				A73639B81D03565400445B24 /* Message.swift */,
 				A796649C1D52213100454C84 /* MessageSubject.swift */,
@@ -1240,6 +1248,7 @@
 				0156B1FE1D075F84000C4252 /* FindFriendsEnvelopeTests.swift */,
 				0156B2111D076028000C4252 /* FriendStatsEnvelopeTests.swift */,
 				A796A8D31D48EAF8009B6EF6 /* ItemTests.swift */,
+				D0BC0E9B1E7094BA006C6D41 /* LiveAuthTokenEnvelopeTests.swift */,
 				A7363A3C1D03588600445B24 /* LocationTests.swift */,
 				A7363A3D1D03588600445B24 /* MessageTests.swift */,
 				A7363A3E1D03588600445B24 /* MessageThreadTests.swift */,
@@ -1908,6 +1917,7 @@
 				A747A8031D455A7300AF199A /* ItemLenses.swift in Sources */,
 				A7472E871D69F6EA0031949A /* PushEnvelopeLenses.swift in Sources */,
 				A7433B0B1D7F84B600C15400 /* SubmitApplePayEnvelope.swift in Sources */,
+				D0BC0E841E709202006C6D41 /* LiveAuthTokenEnvelope.swift in Sources */,
 				59D1E6A11D19C1F600896A4C /* ProjectStatsEnvelope.swift in Sources */,
 				A74176831DAD1E83000EB831 /* ChangePaymentMethodEnvelope.swift in Sources */,
 				59D1E6FF1D1B1CFD00896A4C /* ProjectStatsEnvelope.VideoStatsLenses.swift in Sources */,
@@ -1925,6 +1935,7 @@
 				A7363A121D03565400445B24 /* UserLenses.swift in Sources */,
 				9D9F582E1D1327E300CE81DE /* ProjectActivityEnvelope.swift in Sources */,
 				A777A59A1D05F55A00823FB1 /* VoidEnvelope.swift in Sources */,
+				D0BC0E9A1E709427006C6D41 /* LiveAuthTokenEnvelopeTemplates.swift in Sources */,
 				9D0FB7AB1D761347005774F2 /* CheckoutEnvelope.swift in Sources */,
 				013F78331D1D9EA5005C39F1 /* ProjectStatsEnvelope.RewardDistributionTemplates.swift in Sources */,
 				A777A5AD1D05F66200823FB1 /* User.AvatarLenses.swift in Sources */,
@@ -1986,6 +1997,7 @@
 				809F8B631D08A26B005BADD9 /* UpdateDraftTests.swift in Sources */,
 				A7363A671D03588600445B24 /* RewardTests.swift in Sources */,
 				A757E9BB1D19B8D200A5C978 /* SurveyResponseTests.swift in Sources */,
+				D0BC0E9C1E7094BA006C6D41 /* LiveAuthTokenEnvelopeTests.swift in Sources */,
 				A7363A6F1D03588600445B24 /* User.NotificationsTests.swift in Sources */,
 				A7363A4B1D03588600445B24 /* ActivityTests.swift in Sources */,
 				A7363A511D03588600445B24 /* CommentTests.swift in Sources */,

--- a/KsApi.xcodeproj/project.pbxproj
+++ b/KsApi.xcodeproj/project.pbxproj
@@ -389,6 +389,8 @@
 		A7FD09C81C83E8E900332CCB /* KsApiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A753B56B1C2EED9800FDB616 /* KsApiTests.swift */; };
 		A7FD09CA1C83E8E900332CCB /* KsApi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43C5F91BB358F200C180DA /* KsApi.framework */; };
 		CA43C5FD1BB358F200C180DA /* KsApi.h in Headers */ = {isa = PBXBuildFile; fileRef = CA43C5FC1BB358F200C180DA /* KsApi.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D08986531E709F3E00346EEB /* LiveAuthTokenEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BC0E831E709202006C6D41 /* LiveAuthTokenEnvelope.swift */; };
+		D08986681E709F5000346EEB /* LiveAuthTokenEnvelopeTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BC0E991E709427006C6D41 /* LiveAuthTokenEnvelopeTemplates.swift */; };
 		D0BC0E841E709202006C6D41 /* LiveAuthTokenEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BC0E831E709202006C6D41 /* LiveAuthTokenEnvelope.swift */; };
 		D0BC0E9A1E709427006C6D41 /* LiveAuthTokenEnvelopeTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BC0E991E709427006C6D41 /* LiveAuthTokenEnvelopeTemplates.swift */; };
 		D0BC0E9C1E7094BA006C6D41 /* LiveAuthTokenEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BC0E9B1E7094BA006C6D41 /* LiveAuthTokenEnvelopeTests.swift */; };
@@ -2121,6 +2123,7 @@
 				59F1B71D1D2DB8FA001F7AF5 /* ProjectStatsEnvelope.FundingDateStatsTemplates.swift in Sources */,
 				A7472E881D69F6EA0031949A /* PushEnvelopeLenses.swift in Sources */,
 				A7433B0C1D7F84B600C15400 /* SubmitApplePayEnvelope.swift in Sources */,
+				D08986531E709F3E00346EEB /* LiveAuthTokenEnvelope.swift in Sources */,
 				59B0DF361D0F13960081D2DC /* ProjectNotificationLenses.swift in Sources */,
 				A74176841DAD1E83000EB831 /* ChangePaymentMethodEnvelope.swift in Sources */,
 				A7AFC3621D231B0B00C99E2A /* ProjectStatsEnvelope.CumulativeStatsLenses.swift in Sources */,
@@ -2138,6 +2141,7 @@
 				A7363A051D03565400445B24 /* Project.StatsLenses.swift in Sources */,
 				0156B4281D10D502000C4252 /* FriendStatsEnvelopeTemplates.swift in Sources */,
 				A726620E1D07671D0087D883 /* StarEnvelopeTemplates.swift in Sources */,
+				D08986681E709F5000346EEB /* LiveAuthTokenEnvelopeTemplates.swift in Sources */,
 				9D0FB7AC1D761347005774F2 /* CheckoutEnvelope.swift in Sources */,
 				A7363A131D03565400445B24 /* UserLenses.swift in Sources */,
 				A777A59B1D05F55A00823FB1 /* VoidEnvelope.swift in Sources */,

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -98,6 +98,9 @@ internal struct MockService: ServiceType {
   fileprivate let fetchProjectActivitiesResponse: [Activity]?
   fileprivate let fetchProjectActivitiesError: ErrorEnvelope?
 
+  fileprivate let liveAuthTokenResponse: LiveAuthTokenEnvelope?
+  fileprivate let liveAuthTokenError: ErrorEnvelope?
+
   fileprivate let loginResponse: AccessTokenEnvelope?
   fileprivate let loginError: ErrorEnvelope?
   fileprivate let resendCodeResponse: ErrorEnvelope?
@@ -198,6 +201,8 @@ internal struct MockService: ServiceType {
                 fetchUserSelfError: ErrorEnvelope? = nil,
                 postCommentResponse: Comment? = nil,
                 postCommentError: ErrorEnvelope? = nil,
+                liveAuthTokenResponse: LiveAuthTokenEnvelope? = nil,
+                liveAuthTokenError: ErrorEnvelope? = nil,
                 loginResponse: AccessTokenEnvelope? = nil,
                 loginError: ErrorEnvelope? = nil,
                 resendCodeResponse: ErrorEnvelope? = nil,
@@ -338,6 +343,9 @@ internal struct MockService: ServiceType {
     self.postCommentResponse = postCommentResponse ?? .template
 
     self.postCommentError = postCommentError
+
+    self.liveAuthTokenResponse = liveAuthTokenResponse
+    self.liveAuthTokenError = liveAuthTokenError
 
     self.loginResponse = loginResponse
 
@@ -518,6 +526,16 @@ internal struct MockService: ServiceType {
     }
 
     return SignalProducer(value: VoidEnvelope())
+  }
+
+  internal func liveAuthToken() -> SignalProducer<LiveAuthTokenEnvelope, ErrorEnvelope> {
+    if let error = self.liveAuthTokenError {
+      return SignalProducer(error: error)
+    }
+
+    let envelope = self.liveAuthTokenResponse ?? .template
+
+    return SignalProducer(value: envelope)
   }
 
   internal func login(_ oauthToken: OauthTokenAuthType) -> MockService {

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -328,6 +328,10 @@ public struct Service: ServiceType {
       }
   }
 
+  public func liveAuthToken() -> SignalProducer<LiveAuthTokenEnvelope, ErrorEnvelope> {
+    return request(.liveAuthToken)
+  }
+
   public func login(email: String, password: String, code: String?) ->
     SignalProducer<AccessTokenEnvelope, ErrorEnvelope> {
 

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -193,6 +193,9 @@ public protocol ServiceType {
   /// Increment the video start stat for a project.
   func incrementVideoStart(forProject project: Project) -> SignalProducer<VoidEnvelope, ErrorEnvelope>
 
+  /// Retrieve an auth token for live chat for the logged in user.
+  func liveAuthToken() -> SignalProducer<LiveAuthTokenEnvelope, ErrorEnvelope>
+
   /// Attempt a login with an email, password and optional code.
   func login(email: String, password: String, code: String?) ->
     SignalProducer<AccessTokenEnvelope, ErrorEnvelope>

--- a/KsApi/lib/Route.swift
+++ b/KsApi/lib/Route.swift
@@ -28,6 +28,7 @@ internal enum Route {
   case followFriend(userId: Int)
   case incrementVideoCompletion(project: Project)
   case incrementVideoStart(project: Project)
+  case liveAuthToken
   case login(email: String, password: String, code: String?)
   case markAsRead(MessageThread)
   case messagesForThread(messageThreadId: Int)
@@ -175,6 +176,9 @@ internal enum Route {
       let statsURL = URL(string: project.urls.web.project)?
         .appendingPathComponent("video/plays")
       return (.POST, statsURL?.absoluteString ?? "", ["event_type": "start", "location": "internal"], nil)
+
+    case .liveAuthToken:
+      return (.GET, "/v1/users/self/ksr_live_token", [:], nil)
 
     case let .login(email, password, code):
       var params = ["email": email, "password": password]

--- a/KsApi/models/LiveAuthTokenEnvelope.swift
+++ b/KsApi/models/LiveAuthTokenEnvelope.swift
@@ -15,6 +15,7 @@ extension LiveAuthTokenEnvelope: Decodable {
 }
 
 extension LiveAuthTokenEnvelope {
+  //swiftlint:disable:next type_name
   public enum lens {
     public static let backgroundImage = Lens<LiveAuthTokenEnvelope, String>(
       view: { $0.token },

--- a/KsApi/models/LiveAuthTokenEnvelope.swift
+++ b/KsApi/models/LiveAuthTokenEnvelope.swift
@@ -1,0 +1,24 @@
+import Argo
+import Curry
+import Prelude
+import Runes
+
+public struct LiveAuthTokenEnvelope {
+  public fileprivate(set) var token: String
+}
+
+extension LiveAuthTokenEnvelope: Decodable {
+  public static func decode(_ json: JSON) -> Decoded<LiveAuthTokenEnvelope> {
+    return curry(LiveAuthTokenEnvelope.init)
+      <^> json <| "ksr_live_token"
+  }
+}
+
+extension LiveAuthTokenEnvelope {
+  public enum lens {
+    public static let backgroundImage = Lens<LiveAuthTokenEnvelope, String>(
+      view: { $0.token },
+      set: { var new = $1; new.token = $0; return new }
+    )
+  }
+}

--- a/KsApi/models/templates/LiveAuthTokenEnvelopeTemplates.swift
+++ b/KsApi/models/templates/LiveAuthTokenEnvelopeTemplates.swift
@@ -1,0 +1,5 @@
+extension LiveAuthTokenEnvelope {
+  internal static let template = LiveAuthTokenEnvelope(
+    token: "19b703c03de8efdf628694ce4c91a7bf8a6c98cfcbb7a089abbd488fdd166c4b"
+  )
+}

--- a/KsApiTests/models/LiveAuthTokenEnvelopeTests.swift
+++ b/KsApiTests/models/LiveAuthTokenEnvelopeTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import KsApi
+@testable import Argo
+
+final class LiveAuthTokenEnvelopeTests: XCTestCase {
+  func testJsonDecoding() {
+    let json: [String:Any] = [
+      "ksr_live_token": "19b703c03de8efdf628694ce4c91a7bf8a6c98cfcbb7a089abbd488fdd166c4b"
+    ]
+
+    let envelope = LiveAuthTokenEnvelope.decodeJSONDictionary(json)
+
+    XCTAssertNil(envelope.error)
+    XCTAssertEqual("19b703c03de8efdf628694ce4c91a7bf8a6c98cfcbb7a089abbd488fdd166c4b", envelope.value?.token)
+  }
+}


### PR DESCRIPTION
We encountered a challenge in authorizing logged in ksr users for live chat:

- Live chat happens through Firebase and we auth users using a custom token which we get back from Huzza.
- In order for Huzza to trust that the user ID that we are sending is legitimate we send an accompanying hash of that user ID.
- Naturally we can't store the secret for this hash in our app so the decision was taken to create an additional ksr endpoint that would pass back the hashed user ID for the currently logged in user thus protecting it behind our current oauth security.

This PR adds that endpoint to the app.

The related web PR: https://github.com/kickstarter/kickstarter/pull/6045