### PR TITLE
Add live auth token to User

### DIFF
--- a/KsApi/models/User.swift
+++ b/KsApi/models/User.swift
@@ -7,6 +7,7 @@ public struct User {
   public let facebookConnected: Bool?
   public let id: Int
   public let isFriend: Bool?
+  public let liveAuthToken: String?
   public let location: Location?
   public let name: String
   public let newsletters: NewsletterSubscriptions
@@ -75,6 +76,7 @@ extension User: Decodable {
       <*> json <|? "facebook_connected"
       <*> json <| "id"
       <*> json <|? "is_friend"
+      <*> json <|? "ksr_live_token"
       <*> (json <|? "location" <|> .success(nil))
     return tmp
       <*> json <| "name"
@@ -92,6 +94,7 @@ extension User: EncodableType {
     result["facebook_connected"] = self.facebookConnected ?? false
     result["id"] = self.id
     result["is_friend"] = self.isFriend ?? false
+    result["ksr_live_token"] = self.liveAuthToken
     result["location"] = self.location?.encode()
     result["name"] = self.name
     result = result.withAllValuesFrom(self.newsletters.encode())

--- a/KsApi/models/UserTests.swift
+++ b/KsApi/models/UserTests.swift
@@ -28,6 +28,7 @@ final class UserTests: XCTestCase {
       "happening_newsletter": false,
       "games_newsletter": false,
       "facebook_connected": false,
+      "ksr_live_token": "token",
       "location": [
         "country": "US",
         "id": 12,
@@ -49,6 +50,7 @@ final class UserTests: XCTestCase {
     XCTAssertEqual(false, user?.newsletters.games)
     XCTAssertEqual(false, user?.facebookConnected)
     XCTAssertEqual(false, user?.isFriend)
+    XCTAssertEqual("token", user?.liveAuthToken)
     XCTAssertNotNil(user?.location)
     XCTAssertEqual(json as NSDictionary?, user?.encode() as NSDictionary?)
   }
@@ -68,6 +70,7 @@ final class UserTests: XCTestCase {
       "promo_newsletter": false,
       "weekly_newsletter": false,
       "facebook_connected": false,
+      "ksr_live_token": "token",
       "location": [
         "country": "US",
         "id": 12,

--- a/KsApi/models/lenses/UserLenses.swift
+++ b/KsApi/models/lenses/UserLenses.swift
@@ -6,72 +6,78 @@ extension User {
     public static let avatar = Lens<User, User.Avatar>(
       view: { $0.avatar },
       set: { User(avatar: $0, facebookConnected: $1.facebookConnected, id: $1.id, isFriend: $1.isFriend,
-        location: $1.location, name: $1.name, newsletters: $1.newsletters, notifications: $1.notifications,
-        social: $1.social, stats: $1.stats) }
+        liveAuthToken: $1.liveAuthToken, location: $1.location, name: $1.name, newsletters: $1.newsletters,
+        notifications: $1.notifications, social: $1.social, stats: $1.stats) }
     )
 
     public static let facebookConnected = Lens<User, Bool?>(
       view: { $0.facebookConnected },
       set: { User(avatar: $1.avatar, facebookConnected: $0, id: $1.id, isFriend: $1.isFriend,
-        location: $1.location, name: $1.name, newsletters: $1.newsletters, notifications: $1.notifications,
-        social: $1.social, stats: $1.stats) }
+        liveAuthToken: $1.liveAuthToken, location: $1.location, name: $1.name, newsletters: $1.newsletters,
+        notifications: $1.notifications, social: $1.social, stats: $1.stats) }
     )
 
     public static let id = Lens<User, Int>(
       view: { $0.id },
       set: { User(avatar: $1.avatar, facebookConnected: $1.facebookConnected, id: $0, isFriend: $1.isFriend,
-        location: $1.location, name: $1.name, newsletters: $1.newsletters, notifications: $1.notifications,
-        social: $1.social, stats: $1.stats) }
+        liveAuthToken: $1.liveAuthToken, location: $1.location, name: $1.name, newsletters: $1.newsletters,
+        notifications: $1.notifications, social: $1.social, stats: $1.stats) }
     )
 
     public static let isFriend = Lens<User, Bool?>(
       view: { $0.isFriend },
       set: { User(avatar: $1.avatar, facebookConnected: $1.facebookConnected, id: $1.id, isFriend: $0,
-        location: $1.location, name: $1.name, newsletters: $1.newsletters, notifications: $1.notifications,
-        social: $1.social, stats: $1.stats) }
+        liveAuthToken: $1.liveAuthToken, location: $1.location, name: $1.name, newsletters: $1.newsletters,
+        notifications: $1.notifications, social: $1.social, stats: $1.stats) }
+    )
+
+    public static let liveAuthToken = Lens<User, String?>(
+      view: { $0.liveAuthToken },
+      set: { User(avatar: $1.avatar, facebookConnected: $1.facebookConnected, id: $1.id,
+        isFriend: $1.isFriend, liveAuthToken: $0, location: $1.location, name: $1.name,
+        newsletters: $1.newsletters, notifications: $1.notifications, social: $1.social, stats: $1.stats) }
     )
 
     public static let location = Lens<User, Location?>(
       view: { $0.location },
       set: { User(avatar: $1.avatar, facebookConnected: $1.facebookConnected, id: $1.id,
-        isFriend: $1.isFriend, location: $0, name: $1.name, newsletters: $1.newsletters,
-        notifications: $1.notifications,
-        social: $1.social, stats: $1.stats) }
+        isFriend: $1.isFriend, liveAuthToken: $1.liveAuthToken, location: $0, name: $1.name,
+        newsletters: $1.newsletters, notifications: $1.notifications, social: $1.social, stats: $1.stats) }
     )
 
     public static let name = Lens<User, String>(
       view: { $0.name },
       set: { User(avatar: $1.avatar, facebookConnected: $1.facebookConnected, id: $1.id,
-        isFriend: $1.isFriend, location: $1.location, name: $0, newsletters: $1.newsletters,
-        notifications: $1.notifications, social: $1.social, stats: $1.stats) }
+        isFriend: $1.isFriend, liveAuthToken: $1.liveAuthToken, location: $1.location, name: $0,
+        newsletters: $1.newsletters, notifications: $1.notifications, social: $1.social, stats: $1.stats) }
     )
 
     public static let newsletters = Lens<User, User.NewsletterSubscriptions>(
       view: { $0.newsletters },
       set: { User(avatar: $1.avatar, facebookConnected: $1.facebookConnected, id: $1.id,
-        isFriend: $1.isFriend, location: $1.location, name: $1.name, newsletters: $0,
-        notifications: $1.notifications, social: $1.social, stats: $1.stats) }
+        isFriend: $1.isFriend, liveAuthToken: $1.liveAuthToken, location: $1.location, name: $1.name,
+        newsletters: $0, notifications: $1.notifications, social: $1.social, stats: $1.stats) }
     )
 
     public static let notifications = Lens<User, User.Notifications>(
       view: { $0.notifications },
       set: { User(avatar: $1.avatar, facebookConnected: $1.facebookConnected, id: $1.id,
-        isFriend: $1.isFriend, location: $1.location, name: $1.name, newsletters: $1.newsletters,
-        notifications: $0, social: $1.social, stats: $1.stats) }
+        isFriend: $1.isFriend, liveAuthToken: $1.liveAuthToken, location: $1.location, name: $1.name,
+        newsletters: $1.newsletters, notifications: $0, social: $1.social, stats: $1.stats) }
     )
 
     public static let social = Lens<User, Bool?>(
       view: { $0.social },
       set: { User(avatar: $1.avatar, facebookConnected: $1.facebookConnected, id: $1.id,
-        isFriend: $1.isFriend, location: $1.location, name: $1.name, newsletters: $1.newsletters,
-        notifications: $1.notifications, social: $0, stats: $1.stats) }
+        isFriend: $1.isFriend, liveAuthToken: $1.liveAuthToken, location: $1.location, name: $1.name,
+        newsletters: $1.newsletters, notifications: $1.notifications, social: $0, stats: $1.stats) }
     )
 
     public static let stats = Lens<User, User.Stats>(
       view: { $0.stats },
       set: { User(avatar: $1.avatar, facebookConnected: $1.facebookConnected, id: $1.id,
-        isFriend: $1.isFriend, location: $1.location, name: $1.name, newsletters: $1.newsletters,
-        notifications: $1.notifications, social: $1.social, stats: $0) }
+        isFriend: $1.isFriend, liveAuthToken: $1.liveAuthToken, location: $1.location, name: $1.name,
+        newsletters: $1.newsletters, notifications: $1.notifications, social: $1.social, stats: $0) }
     )
   }
 }

--- a/KsApi/models/templates/UserTemplates.swift
+++ b/KsApi/models/templates/UserTemplates.swift
@@ -7,7 +7,7 @@ extension User {
     facebookConnected: nil,
     id: 1,
     isFriend: nil,
-    liveAuthToken: "token",
+    liveAuthToken: "deadbeef",
     location: nil,
     name: "Blob",
     newsletters: .template,

--- a/KsApi/models/templates/UserTemplates.swift
+++ b/KsApi/models/templates/UserTemplates.swift
@@ -7,6 +7,7 @@ extension User {
     facebookConnected: nil,
     id: 1,
     isFriend: nil,
+    liveAuthToken: "token",
     location: nil,
     name: "Blob",
     newsletters: .template,


### PR DESCRIPTION
This adds the live auth token to the `User` model, explained [here](https://github.com/kickstarter/kickstarter/pull/6170) and [here](https://github.com/kickstarter/ios-ksapi/pull/15).

Even though it should always be returned I've kept it as optional because:

- It's not returned on `FindFriends` which uses the same `User` model
- The edge case mentioned in the web PR above.