### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,3 @@
 > **Moved!** This library has been incorporated into [the main Kickstarter repo](https://github.com/kickstarter/ios-oss).
 
 A library for interacting with Kickstarter's API.
-
-## Dependencies
-
-We make heavy use of the following projects, and so it can be helpful to be familiar with them:
-
-### 1st party
-
-* [![Circle CI](https://circleci.com/gh/kickstarter/Kickstarter-Prelude.svg?style=svg)](https://circleci.com/gh/kickstarter/Kickstarter-Prelude)
-[Prelude](https://github.com/kickstarter/Kickstarter-Prelude): Foundation of
-types and functions we feel are missing from the Swift standard library.
-
-* [![Circle CI](https://circleci.com/gh/kickstarter/Kickstarter-ReactiveExtensions.svg?style=svg&)](https://circleci.com/gh/kickstarter/Kickstarter-ReactiveExtensions)
-[ReactiveExtensions](https://github.com/kickstarter/Kickstarter-ReactiveExtensions):
-A collection of operators we like to add to ReactiveCocoa.
-
-### 3rd party
-
-* [Argo](https://github.com/thoughtbot/Argo)
-* [ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveCocoa)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KsApi
 
-[![CircleCI](https://circleci.com/gh/kickstarter/ios-ksapi.svg?style=svg)](https://circleci.com/gh/kickstarter/ios-ksapi)
+> **Moved!** This library has been incorporated into [the main Kickstarter repo](https://github.com/kickstarter/ios-oss).
 
 A library for interacting with Kickstarter's API.
 


### PR DESCRIPTION
Directs folks to the main app. KsApi is actually mentioned here:

http://raccommunity.github.io/racurated/

Any idea why we made the repo private, @justinswart? It should probably still be public to allow folks to find the main repo.